### PR TITLE
feat #8: 3D ルームエディタ（Three.js でルーム作成・アイテム配置）

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -113,6 +113,9 @@ max-branches = 12
 "src/**/schemas/**/*.py" = [
     "TCH003",  # Pydantic BaseModel はランタイムで型解決が必要
 ]
+"src/**/api/**/*.py" = [
+    "B008",    # FastAPI Depends() は引数デフォルトとして呼び出す必要がある
+]
 "alembic/**/*.py" = [
     "ANN",     # マイグレーションの型注釈は任意
     "ERA001",  # コメントアウトコード許可

--- a/backend/src/memory_palace/api/rooms.py
+++ b/backend/src/memory_palace/api/rooms.py
@@ -1,0 +1,187 @@
+"""Room CRUD API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+
+from memory_palace.database import get_db
+from memory_palace.models.memory_item import MemoryItem
+from memory_palace.models.room import Room
+from memory_palace.schemas.memory_item import (
+    MemoryItemCreate,
+    MemoryItemResponse,
+    MemoryItemUpdate,
+)
+from memory_palace.schemas.room import RoomCreate, RoomResponse, RoomUpdate
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/rooms", tags=["rooms"])
+
+
+def _get_room_or_404(db: Session, room_id: uuid.UUID) -> Room:
+    """Retrieve a room by ID or raise 404."""
+    room = db.execute(select(Room).where(Room.id == room_id)).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Room {room_id} not found",
+        )
+    return room
+
+
+def _get_item_or_404(db: Session, item_id: uuid.UUID, room_id: uuid.UUID) -> MemoryItem:
+    """Retrieve a memory item by ID within a room or raise 404."""
+    item = db.execute(
+        select(MemoryItem).where(
+            MemoryItem.id == item_id,
+            MemoryItem.room_id == room_id,
+        )
+    ).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"MemoryItem {item_id} not found in room {room_id}",
+        )
+    return item
+
+
+# =============================================================================
+# Room CRUD
+# =============================================================================
+
+
+@router.get("", response_model=list[RoomResponse])
+def list_rooms(db: Session = Depends(get_db)) -> list[Room]:
+    """List all rooms.
+
+    Note: MVP does not implement auth. Owner filtering will be added later.
+    """
+    return list(db.execute(select(Room).order_by(Room.created_at.desc())).scalars().all())
+
+
+@router.post("", response_model=RoomResponse, status_code=status.HTTP_201_CREATED)
+def create_room(body: RoomCreate, db: Session = Depends(get_db)) -> Room:
+    """Create a new room.
+
+    Note: MVP uses a hardcoded owner_id. Auth will be added later.
+    """
+    # MVP: use a deterministic dummy owner id until auth is implemented
+    dummy_owner_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    room = Room(
+        owner_id=dummy_owner_id,
+        name=body.name,
+        description=body.description,
+        layout_data=body.layout_data,
+    )
+    db.add(room)
+    db.commit()
+    db.refresh(room)
+    return room
+
+
+@router.get("/{room_id}", response_model=RoomResponse)
+def get_room(room_id: uuid.UUID, db: Session = Depends(get_db)) -> Room:
+    """Get a room by ID."""
+    return _get_room_or_404(db, room_id)
+
+
+@router.patch("/{room_id}", response_model=RoomResponse)
+def update_room(room_id: uuid.UUID, body: RoomUpdate, db: Session = Depends(get_db)) -> Room:
+    """Update a room."""
+    room = _get_room_or_404(db, room_id)
+    update_data = body.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(room, key, value)
+    db.commit()
+    db.refresh(room)
+    return room
+
+
+@router.delete("/{room_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_room(room_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a room and all its memory items (cascade)."""
+    room = _get_room_or_404(db, room_id)
+    db.delete(room)
+    db.commit()
+
+
+# =============================================================================
+# MemoryItem CRUD (nested under rooms)
+# =============================================================================
+
+
+@router.get("/{room_id}/items", response_model=list[MemoryItemResponse])
+def list_items(room_id: uuid.UUID, db: Session = Depends(get_db)) -> list[MemoryItem]:
+    """List all memory items in a room."""
+    _get_room_or_404(db, room_id)
+    return list(
+        db.execute(select(MemoryItem).where(MemoryItem.room_id == room_id).order_by(MemoryItem.created_at))
+        .scalars()
+        .all()
+    )
+
+
+@router.post("/{room_id}/items", response_model=MemoryItemResponse, status_code=status.HTTP_201_CREATED)
+def create_item(room_id: uuid.UUID, body: MemoryItemCreate, db: Session = Depends(get_db)) -> MemoryItem:
+    """Create a memory item in a room."""
+    _get_room_or_404(db, room_id)
+    item = MemoryItem(
+        room_id=room_id,
+        content=body.content,
+        image_url=body.image_url,
+        position_x=body.position.x,
+        position_y=body.position.y,
+        position_z=body.position.z,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.get("/{room_id}/items/{item_id}", response_model=MemoryItemResponse)
+def get_item(room_id: uuid.UUID, item_id: uuid.UUID, db: Session = Depends(get_db)) -> MemoryItem:
+    """Get a memory item by ID."""
+    return _get_item_or_404(db, item_id, room_id)
+
+
+@router.patch("/{room_id}/items/{item_id}", response_model=MemoryItemResponse)
+def update_item(
+    room_id: uuid.UUID,
+    item_id: uuid.UUID,
+    body: MemoryItemUpdate,
+    db: Session = Depends(get_db),
+) -> MemoryItem:
+    """Update a memory item (content, position, image_url)."""
+    item = _get_item_or_404(db, item_id, room_id)
+    update_data = body.model_dump(exclude_unset=True)
+
+    # Handle nested position schema
+    if "position" in update_data and update_data["position"] is not None:
+        position = update_data.pop("position")
+        item.position_x = position["x"]
+        item.position_y = position["y"]
+        item.position_z = position["z"]
+    else:
+        update_data.pop("position", None)
+
+    for key, value in update_data.items():
+        setattr(item, key, value)
+
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{room_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item(room_id: uuid.UUID, item_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a memory item."""
+    item = _get_item_or_404(db, item_id, room_id)
+    db.delete(item)
+    db.commit()

--- a/backend/src/memory_palace/main.py
+++ b/backend/src/memory_palace/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from memory_palace.api.health import router as health_router
+from memory_palace.api.rooms import router as rooms_router
 
 
 def create_app() -> FastAPI:
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(health_router)
+    app.include_router(rooms_router)
 
     return app
 

--- a/backend/src/memory_palace/models/memory_item.py
+++ b/backend/src/memory_palace/models/memory_item.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -29,11 +28,12 @@ class MemoryItem(Base):
     __tablename__ = "memory_items"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     room_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("rooms.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/review_record.py
+++ b/backend/src/memory_palace/models/review_record.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, Integer, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -34,17 +33,18 @@ class ReviewRecord(Base):
     __tablename__ = "review_records"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     session_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("review_sessions.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
     memory_item_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("memory_items.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/review_session.py
+++ b/backend/src/memory_palace/models/review_session.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, Integer, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -26,11 +25,12 @@ class ReviewSession(Base):
     __tablename__ = "review_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     room_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("rooms.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/room.py
+++ b/backend/src/memory_palace/models/room.py
@@ -6,8 +6,8 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -23,11 +23,12 @@ class Room(Base):
     __tablename__ = "rooms"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     owner_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/user.py
+++ b/backend/src/memory_palace/models/user.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import DateTime, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -21,6 +21,7 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )

--- a/backend/tests/test_rooms_api.py
+++ b/backend/tests/test_rooms_api.py
@@ -1,0 +1,420 @@
+"""Tests for Room and MemoryItem CRUD API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from memory_palace.database import Base, get_db
+from memory_palace.main import app
+from memory_palace.models.user import User
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.orm import Session
+
+# Shared engine for all tests — StaticPool ensures the same in-memory DB is reused.
+_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_TestSessionLocal = sessionmaker(bind=_engine)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    """Create all tables before each test and drop after."""
+    Base.metadata.create_all(_engine)
+
+    # Create dummy user required by Room.owner_id FK
+    session = _TestSessionLocal()
+    existing = session.query(User).filter_by(id=uuid.UUID("00000000-0000-0000-0000-000000000001")).first()
+    if not existing:
+        dummy_user = User(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            username="testuser",
+            email="test@example.com",
+            password_hash="hash",
+        )
+        session.add(dummy_user)
+        session.commit()
+    session.close()
+
+    yield
+
+    Base.metadata.drop_all(_engine)
+
+
+def _override_get_db() -> Generator[Session, None, None]:
+    session = _TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create a test client with overridden database dependency."""
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+# =============================================================================
+# Room CRUD tests
+# =============================================================================
+
+
+class TestRoomAPI:
+    """Tests for Room CRUD endpoints."""
+
+    def test_list_rooms_empty(self, client: TestClient):
+        """GET /api/rooms returns empty list when no rooms exist."""
+        response = client.get("/api/rooms")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_room(self, client: TestClient):
+        """POST /api/rooms creates a new room."""
+        response = client.post(
+            "/api/rooms",
+            json={"name": "Test Room", "description": "A test room"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Test Room"
+        assert data["description"] == "A test room"
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_room_minimal(self, client: TestClient):
+        """POST /api/rooms works with only required fields."""
+        response = client.post("/api/rooms", json={"name": "Minimal"})
+        assert response.status_code == 201
+        assert response.json()["name"] == "Minimal"
+
+    def test_create_room_empty_name_rejected(self, client: TestClient):
+        """POST /api/rooms rejects empty name."""
+        response = client.post("/api/rooms", json={"name": ""})
+        assert response.status_code == 422
+
+    def test_create_room_name_too_long_rejected(self, client: TestClient):
+        """POST /api/rooms rejects name longer than 100 chars."""
+        response = client.post("/api/rooms", json={"name": "a" * 101})
+        assert response.status_code == 422
+
+    def test_get_room(self, client: TestClient):
+        """GET /api/rooms/{room_id} returns the room."""
+        create_resp = client.post("/api/rooms", json={"name": "Get Room"})
+        room_id = create_resp.json()["id"]
+
+        response = client.get(f"/api/rooms/{room_id}")
+        assert response.status_code == 200
+        assert response.json()["name"] == "Get Room"
+
+    def test_get_room_not_found(self, client: TestClient):
+        """GET /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}")
+        assert response.status_code == 404
+
+    def test_update_room(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} updates the room."""
+        create_resp = client.post("/api/rooms", json={"name": "Original"})
+        room_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}",
+            json={"name": "Updated"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Updated"
+
+    def test_update_room_partial(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} supports partial updates."""
+        create_resp = client.post(
+            "/api/rooms",
+            json={"name": "Partial", "description": "Original desc"},
+        )
+        room_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}",
+            json={"description": "New desc"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Partial"
+        assert data["description"] == "New desc"
+
+    def test_update_room_not_found(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.patch(f"/api/rooms/{fake_id}", json={"name": "X"})
+        assert response.status_code == 404
+
+    def test_delete_room(self, client: TestClient):
+        """DELETE /api/rooms/{room_id} removes the room."""
+        create_resp = client.post("/api/rooms", json={"name": "To Delete"})
+        room_id = create_resp.json()["id"]
+
+        response = client.delete(f"/api/rooms/{room_id}")
+        assert response.status_code == 204
+
+        # Confirm deletion
+        get_resp = client.get(f"/api/rooms/{room_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_room_not_found(self, client: TestClient):
+        """DELETE /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.delete(f"/api/rooms/{fake_id}")
+        assert response.status_code == 404
+
+    def test_list_rooms_returns_created_rooms(self, client: TestClient):
+        """GET /api/rooms lists all created rooms."""
+        client.post("/api/rooms", json={"name": "Room 1"})
+        client.post("/api/rooms", json={"name": "Room 2"})
+
+        response = client.get("/api/rooms")
+        assert response.status_code == 200
+        rooms = response.json()
+        assert len(rooms) == 2
+
+    def test_create_room_with_layout_data(self, client: TestClient):
+        """POST /api/rooms stores layout_data."""
+        layout = {"floor": {"width": 20, "depth": 20}, "walls": []}
+        response = client.post(
+            "/api/rooms",
+            json={"name": "Layout Room", "layout_data": layout},
+        )
+        assert response.status_code == 201
+        assert response.json()["layout_data"]["floor"]["width"] == 20
+
+
+# =============================================================================
+# MemoryItem CRUD tests
+# =============================================================================
+
+
+class TestMemoryItemAPI:
+    """Tests for MemoryItem CRUD endpoints nested under rooms."""
+
+    @pytest.fixture
+    def room_id(self, client: TestClient) -> str:
+        """Create a room and return its ID."""
+        resp = client.post("/api/rooms", json={"name": "Item Test Room"})
+        return resp.json()["id"]
+
+    def test_list_items_empty(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items returns empty list."""
+        response = client.get(f"/api/rooms/{room_id}/items")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_item(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items creates a memory item."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "The capital of France is Paris",
+                "position": {"x": 1.0, "y": 0.0, "z": 2.5},
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["content"] == "The capital of France is Paris"
+        assert data["position_x"] == 1.0
+        assert data["position_z"] == 2.5
+        assert data["room_id"] == room_id
+        # Check SM-2 defaults
+        assert data["ease_factor"] == 2.5
+        assert data["interval"] == 1
+        assert data["repetitions"] == 0
+
+    def test_create_item_default_position(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items uses default position (0,0,0)."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Default position item"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["position_x"] == 0.0
+        assert data["position_y"] == 0.0
+        assert data["position_z"] == 0.0
+
+    def test_create_item_empty_content_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects empty content."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_content_too_long_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects content over 10000 chars."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "a" * 10001, "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_position_out_of_bounds_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects out-of-bounds positions."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "OOB", "position": {"x": 2000.0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_nonexistent_room(self, client: TestClient):
+        """POST /api/rooms/{room_id}/items returns 404 for fake room."""
+        fake_id = str(uuid.uuid4())
+        response = client.post(
+            f"/api/rooms/{fake_id}/items",
+            json={"content": "Test", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 404
+
+    def test_get_item(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items/{item_id} returns the item."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Get me", "position": {"x": 1, "y": 0, "z": 1}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        assert response.status_code == 200
+        assert response.json()["content"] == "Get me"
+
+    def test_get_item_not_found(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{room_id}/items/{fake_id}")
+        assert response.status_code == 404
+
+    def test_update_item_content(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} updates content."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Original", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{item_id}",
+            json={"content": "Updated"},
+        )
+        assert response.status_code == 200
+        assert response.json()["content"] == "Updated"
+
+    def test_update_item_position(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} updates position."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Move me", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{item_id}",
+            json={"position": {"x": 5.0, "y": 0.0, "z": 3.0}},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["position_x"] == 5.0
+        assert data["position_z"] == 3.0
+
+    def test_update_item_not_found(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{fake_id}",
+            json={"content": "X"},
+        )
+        assert response.status_code == 404
+
+    def test_delete_item(self, client: TestClient, room_id: str):
+        """DELETE /api/rooms/{room_id}/items/{item_id} removes the item."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Delete me", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.delete(f"/api/rooms/{room_id}/items/{item_id}")
+        assert response.status_code == 204
+
+        # Confirm deletion
+        get_resp = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_item_not_found(self, client: TestClient, room_id: str):
+        """DELETE /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.delete(f"/api/rooms/{room_id}/items/{fake_id}")
+        assert response.status_code == 404
+
+    def test_list_items_returns_all_items(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items returns all items."""
+        for i in range(3):
+            client.post(
+                f"/api/rooms/{room_id}/items",
+                json={
+                    "content": f"Item {i}",
+                    "position": {"x": float(i), "y": 0, "z": 0},
+                },
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/items")
+        assert response.status_code == 200
+        assert len(response.json()) == 3
+
+    def test_delete_room_cascades_to_items(self, client: TestClient, room_id: str):
+        """Deleting a room also deletes its items."""
+        client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Cascade test", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+
+        client.delete(f"/api/rooms/{room_id}")
+
+        # Room and items should be gone
+        assert client.get(f"/api/rooms/{room_id}").status_code == 404
+
+    def test_create_item_with_image_url(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items supports image_url."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "Item with image",
+                "image_url": "https://example.com/img.png",
+                "position": {"x": 0, "y": 0, "z": 0},
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["image_url"] == "https://example.com/img.png"
+
+    def test_item_content_up_to_500_accepted(self, client: TestClient, room_id: str):
+        """Items with content up to 500 chars are accepted."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "a" * 500,
+                "position": {"x": 0, "y": 0, "z": 0},
+            },
+        )
+        assert response.status_code == 201

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -36,7 +36,8 @@
 					}
 				},
 				"noForEach": "warn",
-				"useSimplifiedLogicExpression": "warn"
+				"useSimplifiedLogicExpression": "warn",
+				"useLiteralKeys": "off"
 			},
 			"correctness": {
 				"noUnusedImports": "error",

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,15 +1,125 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
+// Mock the API module
+vi.mock("@/lib/api", () => ({
+	roomApi: {
+		list: vi.fn(),
+		create: vi.fn(),
+		delete: vi.fn(),
+	},
+	itemApi: {
+		list: vi.fn(),
+	},
+}));
+
+// Import mocked module
+const { roomApi } = await import("@/lib/api");
+
+beforeEach(() => {
+	vi.mocked(roomApi.list).mockResolvedValue([]);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("App", () => {
-	it("renders the heading", () => {
+	it("renders the heading", async () => {
 		render(<App />);
 		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Memory Palace");
 	});
 
-	it("renders the description text", () => {
+	it("renders the description text", async () => {
 		render(<App />);
 		expect(screen.getByText("記憶宮殿 - 間隔反復学習ツール")).toBeDefined();
+	});
+
+	it("shows empty state when no rooms exist", async () => {
+		vi.mocked(roomApi.list).mockResolvedValue([]);
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("no-rooms-message")).toBeDefined();
+		});
+	});
+
+	it("displays rooms from the API", async () => {
+		vi.mocked(roomApi.list).mockResolvedValue([
+			{
+				id: "room-1",
+				owner_id: "owner-1",
+				name: "My Room",
+				description: null,
+				layout_data: null,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+			},
+		]);
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-list")).toBeDefined();
+			expect(screen.getByText("My Room")).toBeDefined();
+		});
+	});
+
+	it("has a room name input and create button", async () => {
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-name-input")).toBeDefined();
+			expect(screen.getByTestId("create-room-button")).toBeDefined();
+		});
+	});
+
+	it("create button is disabled when input is empty", async () => {
+		render(<App />);
+
+		await waitFor(() => {
+			const button = screen.getByTestId("create-room-button");
+			expect(button).toBeDisabled();
+		});
+	});
+
+	it("creates a room when form is submitted", async () => {
+		const user = userEvent.setup();
+		vi.mocked(roomApi.create).mockResolvedValue({
+			id: "new-room",
+			owner_id: "owner-1",
+			name: "New Room",
+			description: null,
+			layout_data: null,
+			created_at: "2026-01-01T00:00:00Z",
+			updated_at: "2026-01-01T00:00:00Z",
+		});
+
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-name-input")).toBeDefined();
+		});
+
+		const input = screen.getByTestId("room-name-input");
+		const button = screen.getByTestId("create-room-button");
+
+		await user.type(input, "New Room");
+		await user.click(button);
+
+		await waitFor(() => {
+			expect(roomApi.create).toHaveBeenCalledWith({ name: "New Room" });
+			expect(screen.getByText("New Room")).toBeDefined();
+		});
+	});
+
+	it("shows error message on API failure", async () => {
+		vi.mocked(roomApi.list).mockRejectedValue(new Error("Network error"));
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("error-message")).toBeDefined();
+		});
 	});
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,227 @@
+import { RoomEditor } from "@/components/RoomEditor";
+import { roomApi } from "@/lib/api";
+import type { Room, RoomCreateRequest } from "@/types/api";
+import { useCallback, useEffect, useState } from "react";
+
+type View = { type: "list" } | { type: "editor"; roomId: string };
+
 export function App(): React.JSX.Element {
+	const [view, setView] = useState<View>({ type: "list" });
+	const [rooms, setRooms] = useState<Room[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [newRoomName, setNewRoomName] = useState("");
+
+	const loadRooms = useCallback(async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			const data = await roomApi.list();
+			setRooms(data);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load rooms");
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadRooms();
+	}, [loadRooms]);
+
+	const handleCreateRoom = async (): Promise<void> => {
+		const name = newRoomName.trim();
+		if (name.length === 0 || name.length > 100) return;
+
+		try {
+			const body: RoomCreateRequest = { name };
+			const room = await roomApi.create(body);
+			setRooms((prev) => [room, ...prev]);
+			setNewRoomName("");
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to create room");
+		}
+	};
+
+	const handleDeleteRoom = async (roomId: string): Promise<void> => {
+		try {
+			await roomApi.delete(roomId);
+			setRooms((prev) => prev.filter((r) => r.id !== roomId));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to delete room");
+		}
+	};
+
+	if (view.type === "editor") {
+		return (
+			<div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+				<div
+					style={{
+						padding: "8px 16px",
+						backgroundColor: "#0a0a1a",
+						borderBottom: "1px solid #2a2a4a",
+					}}
+				>
+					<button
+						type="button"
+						onClick={() => {
+							setView({ type: "list" });
+							loadRooms();
+						}}
+						style={{
+							padding: "6px 12px",
+							backgroundColor: "#2a2a4a",
+							color: "#e0e0e0",
+							border: "1px solid #3a3a5c",
+							borderRadius: "6px",
+							cursor: "pointer",
+							fontSize: "0.85rem",
+						}}
+						data-testid="back-to-list"
+					>
+						← ルーム一覧に戻る
+					</button>
+				</div>
+				<div style={{ flex: 1, overflow: "hidden" }}>
+					<RoomEditor roomId={view.roomId} />
+				</div>
+			</div>
+		);
+	}
+
 	return (
-		<div>
-			<h1>Memory Palace</h1>
-			<p>記憶宮殿 - 間隔反復学習ツール</p>
+		<div
+			style={{
+				minHeight: "100vh",
+				backgroundColor: "#0a0a1a",
+				color: "#e0e0e0",
+				fontFamily: "system-ui, sans-serif",
+				padding: "40px 20px",
+			}}
+		>
+			<div style={{ maxWidth: "600px", margin: "0 auto" }}>
+				<h1 style={{ fontSize: "1.8rem", marginBottom: "8px" }}>Memory Palace</h1>
+				<p style={{ color: "#888", marginBottom: "32px" }}>記憶宮殿 - 間隔反復学習ツール</p>
+
+				{/* Error */}
+				{error && (
+					<p style={{ color: "#ff4444", marginBottom: "16px" }} data-testid="error-message">
+						{error}
+					</p>
+				)}
+
+				{/* Create room */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						htmlFor="room-name-input"
+						style={{ display: "block", marginBottom: "6px", fontSize: "0.9rem", color: "#aaa" }}
+					>
+						新しいルームを作成
+					</label>
+					<div style={{ display: "flex", gap: "8px" }}>
+						<input
+							id="room-name-input"
+							type="text"
+							value={newRoomName}
+							onChange={(e) => setNewRoomName(e.target.value)}
+							placeholder="ルーム名（1-100文字）"
+							maxLength={100}
+							style={{
+								flex: 1,
+								padding: "10px 14px",
+								backgroundColor: "#1a1a2e",
+								border: "1px solid #3a3a5c",
+								borderRadius: "8px",
+								color: "#e0e0e0",
+								fontSize: "0.95rem",
+								outline: "none",
+							}}
+							data-testid="room-name-input"
+						/>
+						<button
+							type="button"
+							onClick={handleCreateRoom}
+							disabled={newRoomName.trim().length === 0}
+							style={{
+								padding: "10px 20px",
+								backgroundColor: newRoomName.trim().length > 0 ? "#0066cc" : "#333",
+								color: newRoomName.trim().length > 0 ? "#fff" : "#666",
+								border: "none",
+								borderRadius: "8px",
+								cursor: newRoomName.trim().length > 0 ? "pointer" : "not-allowed",
+								fontSize: "0.9rem",
+								whiteSpace: "nowrap",
+							}}
+							data-testid="create-room-button"
+						>
+							作成
+						</button>
+					</div>
+				</div>
+
+				{/* Room list */}
+				<h2 style={{ fontSize: "1.1rem", marginBottom: "12px" }}>ルーム一覧</h2>
+
+				{loading ? (
+					<p style={{ color: "#888" }}>読み込み中...</p>
+				) : rooms.length === 0 ? (
+					<p style={{ color: "#666" }} data-testid="no-rooms-message">
+						ルームがありません。上のフォームから作成してください。
+					</p>
+				) : (
+					<ul style={{ listStyle: "none", padding: 0, margin: 0 }} data-testid="room-list">
+						{rooms.map((room) => (
+							<li
+								key={room.id}
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "12px 16px",
+									marginBottom: "8px",
+									backgroundColor: "#1a1a2e",
+									borderRadius: "8px",
+									border: "1px solid #2a2a4a",
+								}}
+							>
+								<button
+									type="button"
+									onClick={() => setView({ type: "editor", roomId: room.id })}
+									style={{
+										background: "none",
+										border: "none",
+										color: "#4488ff",
+										cursor: "pointer",
+										fontSize: "1rem",
+										textAlign: "left",
+										flex: 1,
+										padding: 0,
+									}}
+									data-testid={`room-link-${room.id}`}
+								>
+									{room.name}
+								</button>
+								<button
+									type="button"
+									onClick={() => handleDeleteRoom(room.id)}
+									style={{
+										padding: "4px 10px",
+										backgroundColor: "transparent",
+										color: "#cc3333",
+										border: "1px solid #cc3333",
+										borderRadius: "4px",
+										cursor: "pointer",
+										fontSize: "0.8rem",
+									}}
+									data-testid={`delete-room-${room.id}`}
+								>
+									削除
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/components/RoomEditor.tsx
+++ b/frontend/src/components/RoomEditor.tsx
@@ -1,0 +1,601 @@
+/**
+ * 3D Room Editor component.
+ *
+ * Integrates Three.js scene with React state management.
+ * Handles room rendering, item placement, selection, and CRUD operations.
+ */
+
+import { itemApi, roomApi } from "@/lib/api";
+import { FirstPersonControls } from "@/lib/three/FirstPersonControls";
+import type { ItemManagerCallbacks } from "@/lib/three/ItemManager";
+import { ItemManager } from "@/lib/three/ItemManager";
+import { RoomScene } from "@/lib/three/RoomScene";
+import type { MemoryItem, Room } from "@/types/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+
+/** Props for the RoomEditor component */
+export interface RoomEditorProps {
+	roomId: string;
+}
+
+interface EditorState {
+	room: Room | null;
+	items: MemoryItem[];
+	selectedItemId: string | null;
+	isPlacementMode: boolean;
+	isPointerLocked: boolean;
+	loading: boolean;
+	error: string | null;
+	newItemContent: string;
+	editContent: string;
+}
+
+const INITIAL_STATE: EditorState = {
+	room: null,
+	items: [],
+	selectedItemId: null,
+	isPlacementMode: false,
+	isPointerLocked: false,
+	loading: true,
+	error: null,
+	newItemContent: "",
+	editContent: "",
+};
+
+export function RoomEditor({ roomId }: RoomEditorProps): React.JSX.Element {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const sceneRef = useRef<RoomScene | null>(null);
+	const controlsRef = useRef<FirstPersonControls | null>(null);
+	const itemManagerRef = useRef<ItemManager | null>(null);
+
+	const [state, setState] = useState<EditorState>(INITIAL_STATE);
+
+	// Partial state updater
+	const updateState = useCallback((partial: Partial<EditorState>) => {
+		setState((prev) => ({ ...prev, ...partial }));
+	}, []);
+
+	// =========================================================================
+	// Data fetching
+	// =========================================================================
+
+	const loadRoom = useCallback(async () => {
+		try {
+			updateState({ loading: true, error: null });
+			const [room, items] = await Promise.all([roomApi.get(roomId), itemApi.list(roomId)]);
+			updateState({ room, items, loading: false });
+			return { room, items };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to load room";
+			updateState({ error: message, loading: false });
+			return null;
+		}
+	}, [roomId, updateState]);
+
+	// =========================================================================
+	// Three.js initialization
+	// =========================================================================
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		const container = containerRef.current;
+		if (!(canvas && container)) return;
+
+		const roomScene = new RoomScene(canvas);
+		sceneRef.current = roomScene;
+
+		const dimensions = roomScene.getDimensions();
+
+		const controls = new FirstPersonControls(roomScene.camera, canvas, dimensions);
+		controlsRef.current = controls;
+
+		const callbacks: ItemManagerCallbacks = {
+			onItemPlaced: (position: THREE.Vector3) => {
+				setState((prev) => {
+					if (prev.newItemContent.trim().length === 0) return prev;
+					// Will be handled in placement handler
+					return { ...prev, isPlacementMode: false };
+				});
+				handleItemPlaced(position);
+			},
+			onItemSelected: (itemId: string) => {
+				setState((prev) => {
+					const item = prev.items.find((i) => i.id === itemId);
+					return {
+						...prev,
+						selectedItemId: itemId,
+						editContent: item?.content ?? "",
+					};
+				});
+			},
+			onItemDeselected: () => {
+				setState((prev) => ({
+					...prev,
+					selectedItemId: null,
+					editContent: "",
+				}));
+			},
+		};
+
+		const itemMgr = new ItemManager(roomScene.scene, roomScene.camera, dimensions, callbacks);
+		itemManagerRef.current = itemMgr;
+
+		// Start render loop
+		roomScene.start(() => {
+			controls.update();
+			updateState({ isPointerLocked: controls.getIsLocked() });
+		});
+
+		// Handle resize
+		const resizeObserver = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				const { width, height } = entry.contentRect;
+				if (width > 0 && height > 0) {
+					roomScene.handleResize(width, height);
+				}
+			}
+		});
+		resizeObserver.observe(container);
+
+		// Handle mouse events (only when not pointer-locked)
+		const handleMouseMove = (event: MouseEvent): void => {
+			if (controls.getIsLocked()) return;
+			const rect = canvas.getBoundingClientRect();
+			itemMgr.handleMouseMove(event, rect);
+		};
+
+		const handleClick = (event: MouseEvent): void => {
+			if (controls.getIsLocked()) return;
+			const rect = canvas.getBoundingClientRect();
+			itemMgr.handleClick(event, rect);
+		};
+
+		canvas.addEventListener("mousemove", handleMouseMove);
+		canvas.addEventListener("click", handleClick);
+
+		// Load data and sync to 3D scene
+		loadRoom().then((data) => {
+			if (data) {
+				for (const item of data.items) {
+					itemMgr.addItem(item.id, item.content, new THREE.Vector3(item.position_x, 0, item.position_z));
+				}
+			}
+		});
+
+		return () => {
+			canvas.removeEventListener("mousemove", handleMouseMove);
+			canvas.removeEventListener("click", handleClick);
+			resizeObserver.disconnect();
+			controls.disconnect();
+			itemMgr.dispose();
+			roomScene.dispose();
+			sceneRef.current = null;
+			controlsRef.current = null;
+			itemManagerRef.current = null;
+		};
+	}, [loadRoom, updateState]);
+
+	// =========================================================================
+	// Item CRUD handlers
+	// =========================================================================
+
+	const handleItemPlaced = async (position: THREE.Vector3): Promise<void> => {
+		const content = state.newItemContent.trim();
+		if (content.length === 0 || content.length > 500) return;
+
+		try {
+			const newItem = await itemApi.create(roomId, {
+				content,
+				position: { x: position.x, y: position.y, z: position.z },
+			});
+
+			itemManagerRef.current?.addItem(
+				newItem.id,
+				newItem.content,
+				new THREE.Vector3(newItem.position_x, 0, newItem.position_z),
+			);
+
+			updateState({
+				items: [...state.items, newItem],
+				newItemContent: "",
+				isPlacementMode: false,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to create item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleDeleteItem = async (): Promise<void> => {
+		if (!state.selectedItemId) return;
+
+		try {
+			await itemApi.delete(roomId, state.selectedItemId);
+			itemManagerRef.current?.removeItem(state.selectedItemId);
+
+			updateState({
+				items: state.items.filter((i) => i.id !== state.selectedItemId),
+				selectedItemId: null,
+				editContent: "",
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to delete item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleUpdateItem = async (): Promise<void> => {
+		if (!state.selectedItemId) return;
+
+		const content = state.editContent.trim();
+		if (content.length === 0 || content.length > 500) return;
+
+		try {
+			const updatedItem = await itemApi.update(roomId, state.selectedItemId, { content });
+			itemManagerRef.current?.updateItemContent(state.selectedItemId, content);
+
+			updateState({
+				items: state.items.map((i) => (i.id === state.selectedItemId ? updatedItem : i)),
+				editContent: content,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to update item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleStartPlacement = (): void => {
+		if (state.newItemContent.trim().length === 0) return;
+		if (state.newItemContent.trim().length > 500) {
+			updateState({ error: "アイテムテキストは500文字以内です" });
+			return;
+		}
+		itemManagerRef.current?.setPlacementMode(true);
+		updateState({ isPlacementMode: true, selectedItemId: null });
+	};
+
+	const handleCancelPlacement = (): void => {
+		itemManagerRef.current?.setPlacementMode(false);
+		updateState({ isPlacementMode: false });
+	};
+
+	// =========================================================================
+	// Render
+	// =========================================================================
+
+	if (state.loading) {
+		return (
+			<div style={styles.container} data-testid="room-editor-loading">
+				<p>読み込み中...</p>
+			</div>
+		);
+	}
+
+	if (state.error && !state.room) {
+		return (
+			<div style={styles.container} data-testid="room-editor-error">
+				<p style={styles.errorText}>エラー: {state.error}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div style={styles.container} data-testid="room-editor">
+			{/* Header */}
+			<div style={styles.header}>
+				<h2 style={styles.title}>{state.room?.name ?? "Room"}</h2>
+				<span style={styles.itemCount}>アイテム: {state.items.length}件</span>
+			</div>
+
+			{/* 3D Canvas */}
+			<div ref={containerRef} style={styles.canvasContainer}>
+				<canvas ref={canvasRef} style={styles.canvas} data-testid="room-canvas" />
+
+				{/* Pointer lock instruction overlay */}
+				{!(state.isPointerLocked || state.isPlacementMode) && (
+					<div style={styles.overlay} data-testid="pointer-lock-overlay">
+						<p>クリックして3D空間を操作</p>
+						<p style={styles.overlaySubtext}>WASD: 移動 / マウス: 視点</p>
+						<p style={styles.overlaySubtext}>ESC: 操作解除</p>
+					</div>
+				)}
+
+				{/* Placement mode overlay */}
+				{state.isPlacementMode && (
+					<div style={styles.placementOverlay} data-testid="placement-overlay">
+						<p>床をクリックしてアイテムを配置</p>
+						<button type="button" onClick={handleCancelPlacement} style={styles.cancelButton}>
+							キャンセル
+						</button>
+					</div>
+				)}
+			</div>
+
+			{/* Controls Panel */}
+			<div style={styles.panel}>
+				{/* Error message */}
+				{state.error && <p style={styles.errorText}>{state.error}</p>}
+
+				{/* New item input */}
+				<div style={styles.inputGroup}>
+					<label htmlFor="new-item-content" style={styles.label}>
+						新しいアイテム
+					</label>
+					<div style={styles.inputRow}>
+						<input
+							id="new-item-content"
+							type="text"
+							value={state.newItemContent}
+							onChange={(e) => updateState({ newItemContent: e.target.value })}
+							placeholder="記憶したいテキスト（1-500文字）"
+							maxLength={500}
+							style={styles.input}
+							data-testid="new-item-input"
+						/>
+						<button
+							type="button"
+							onClick={handleStartPlacement}
+							disabled={state.newItemContent.trim().length === 0}
+							style={{
+								...styles.button,
+								...(state.newItemContent.trim().length === 0 ? styles.buttonDisabled : {}),
+							}}
+							data-testid="place-item-button"
+						>
+							配置
+						</button>
+					</div>
+				</div>
+
+				{/* Selected item controls */}
+				{state.selectedItemId && (
+					<div style={styles.selectedPanel} data-testid="selected-item-panel">
+						<label htmlFor="edit-item-content" style={styles.label}>
+							選択中のアイテム
+						</label>
+						<div style={styles.inputRow}>
+							<input
+								id="edit-item-content"
+								type="text"
+								value={state.editContent}
+								onChange={(e) => updateState({ editContent: e.target.value })}
+								maxLength={500}
+								style={styles.input}
+								data-testid="edit-item-input"
+							/>
+							<button
+								type="button"
+								onClick={handleUpdateItem}
+								disabled={state.editContent.trim().length === 0}
+								style={styles.button}
+								data-testid="update-item-button"
+							>
+								更新
+							</button>
+							<button
+								type="button"
+								onClick={handleDeleteItem}
+								style={styles.deleteButton}
+								data-testid="delete-item-button"
+							>
+								削除
+							</button>
+						</div>
+					</div>
+				)}
+
+				{/* Items list */}
+				<div style={styles.itemsList}>
+					<h3 style={styles.itemsListTitle}>配置済みアイテム</h3>
+					{state.items.length === 0 ? (
+						<p style={styles.emptyText}>アイテムがありません。上のフォームから追加してください。</p>
+					) : (
+						<ul style={styles.list}>
+							{state.items.map((item) => (
+								<li
+									key={item.id}
+									style={{
+										...styles.listItem,
+										...(item.id === state.selectedItemId ? styles.listItemSelected : {}),
+									}}
+								>
+									<span style={styles.itemText}>{item.content}</span>
+									<span style={styles.itemPosition}>
+										({item.position_x.toFixed(1)}, {item.position_z.toFixed(1)})
+									</span>
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// =============================================================================
+// Inline styles (MVP — will be replaced by CSS modules or styled-components)
+// =============================================================================
+
+const styles = {
+	container: {
+		display: "flex",
+		flexDirection: "column",
+		height: "100vh",
+		backgroundColor: "#0a0a1a",
+		color: "#e0e0e0",
+		fontFamily: "system-ui, sans-serif",
+	},
+	header: {
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "space-between",
+		padding: "12px 20px",
+		backgroundColor: "#1a1a2e",
+		borderBottom: "1px solid #2a2a4a",
+	},
+	title: {
+		margin: 0,
+		fontSize: "1.2rem",
+		fontWeight: 600,
+	},
+	itemCount: {
+		fontSize: "0.85rem",
+		color: "#888",
+	},
+	canvasContainer: {
+		position: "relative",
+		flex: 1,
+		minHeight: "300px",
+	},
+	canvas: {
+		display: "block",
+		width: "100%",
+		height: "100%",
+	},
+	overlay: {
+		position: "absolute",
+		top: "50%",
+		left: "50%",
+		transform: "translate(-50%, -50%)",
+		textAlign: "center",
+		padding: "24px",
+		backgroundColor: "rgba(0, 0, 0, 0.7)",
+		borderRadius: "12px",
+		pointerEvents: "none",
+	},
+	overlaySubtext: {
+		fontSize: "0.85rem",
+		color: "#888",
+		margin: "4px 0",
+	},
+	placementOverlay: {
+		position: "absolute",
+		top: "20px",
+		left: "50%",
+		transform: "translateX(-50%)",
+		textAlign: "center",
+		padding: "12px 24px",
+		backgroundColor: "rgba(0, 170, 100, 0.85)",
+		borderRadius: "8px",
+	},
+	panel: {
+		padding: "16px 20px",
+		backgroundColor: "#1a1a2e",
+		borderTop: "1px solid #2a2a4a",
+		maxHeight: "250px",
+		overflowY: "auto",
+	},
+	inputGroup: {
+		marginBottom: "12px",
+	},
+	inputRow: {
+		display: "flex",
+		gap: "8px",
+	},
+	label: {
+		display: "block",
+		marginBottom: "4px",
+		fontSize: "0.85rem",
+		color: "#aaa",
+	},
+	input: {
+		flex: 1,
+		padding: "8px 12px",
+		backgroundColor: "#2a2a4a",
+		border: "1px solid #3a3a5c",
+		borderRadius: "6px",
+		color: "#e0e0e0",
+		fontSize: "0.9rem",
+		outline: "none",
+	},
+	button: {
+		padding: "8px 16px",
+		backgroundColor: "#0066cc",
+		color: "#fff",
+		border: "none",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+		whiteSpace: "nowrap",
+	},
+	buttonDisabled: {
+		backgroundColor: "#333",
+		color: "#666",
+		cursor: "not-allowed",
+	},
+	cancelButton: {
+		padding: "6px 14px",
+		backgroundColor: "transparent",
+		color: "#fff",
+		border: "1px solid #fff",
+		borderRadius: "6px",
+		cursor: "pointer",
+		marginTop: "8px",
+	},
+	deleteButton: {
+		padding: "8px 16px",
+		backgroundColor: "#cc3333",
+		color: "#fff",
+		border: "none",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+	},
+	selectedPanel: {
+		marginBottom: "12px",
+		padding: "12px",
+		backgroundColor: "#2a2a4a",
+		borderRadius: "8px",
+		border: "1px solid #ffaa00",
+	},
+	itemsList: {
+		marginTop: "8px",
+	},
+	itemsListTitle: {
+		margin: "0 0 8px",
+		fontSize: "0.9rem",
+		fontWeight: 600,
+	},
+	emptyText: {
+		fontSize: "0.85rem",
+		color: "#666",
+	},
+	list: {
+		listStyle: "none",
+		margin: 0,
+		padding: 0,
+	},
+	listItem: {
+		display: "flex",
+		justifyContent: "space-between",
+		alignItems: "center",
+		padding: "6px 8px",
+		borderRadius: "4px",
+		marginBottom: "4px",
+		backgroundColor: "#2a2a4a",
+	},
+	listItemSelected: {
+		backgroundColor: "#3a3a5c",
+		border: "1px solid #ffaa00",
+	},
+	itemText: {
+		fontSize: "0.85rem",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
+		maxWidth: "70%",
+	},
+	itemPosition: {
+		fontSize: "0.75rem",
+		color: "#888",
+		whiteSpace: "nowrap",
+	},
+	errorText: {
+		color: "#ff4444",
+		fontSize: "0.85rem",
+		marginBottom: "8px",
+	},
+} satisfies Record<string, React.CSSProperties>;

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, itemApi, roomApi } from "./api";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function mockResponse(body: unknown, status = 200): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body)),
+		headers: new Headers(),
+		redirected: false,
+		statusText: "OK",
+		type: "basic" as ResponseType,
+		url: "",
+		clone: () => mockResponse(body, status),
+		body: null,
+		bodyUsed: false,
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+		blob: () => Promise.resolve(new Blob()),
+		formData: () => Promise.resolve(new FormData()),
+		bytes: () => Promise.resolve(new Uint8Array()),
+	};
+}
+
+function mockNoContentResponse(): Response {
+	return mockResponse(undefined, 204);
+}
+
+function mockErrorResponse(status: number, message: string): Response {
+	return {
+		...mockResponse(message, status),
+		ok: false,
+		status,
+		text: () => Promise.resolve(message),
+	};
+}
+
+beforeEach(() => {
+	mockFetch.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("roomApi", () => {
+	describe("list", () => {
+		it("fetches rooms from /api/rooms", async () => {
+			const rooms = [{ id: "1", name: "Room 1" }];
+			mockFetch.mockResolvedValueOnce(mockResponse(rooms));
+
+			const result = await roomApi.list();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/rooms",
+				expect.objectContaining({ headers: expect.objectContaining({ "Content-Type": "application/json" }) }),
+			);
+			expect(result).toEqual(rooms);
+		});
+	});
+
+	describe("get", () => {
+		it("fetches a room by ID", async () => {
+			const room = { id: "1", name: "Test Room" };
+			mockFetch.mockResolvedValueOnce(mockResponse(room));
+
+			const result = await roomApi.get("1");
+			expect(result).toEqual(room);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a room with POST", async () => {
+			const newRoom = { id: "1", name: "New Room" };
+			mockFetch.mockResolvedValueOnce(mockResponse(newRoom, 201));
+
+			const result = await roomApi.create({ name: "New Room" });
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/rooms",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ name: "New Room" }),
+				}),
+			);
+			expect(result).toEqual(newRoom);
+		});
+	});
+
+	describe("update", () => {
+		it("updates a room with PATCH", async () => {
+			const updated = { id: "1", name: "Updated" };
+			mockFetch.mockResolvedValueOnce(mockResponse(updated));
+
+			const result = await roomApi.update("1", { name: "Updated" });
+			expect(result).toEqual(updated);
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a room", async () => {
+			mockFetch.mockResolvedValueOnce(mockNoContentResponse());
+
+			await roomApi.delete("1");
+
+			expect(mockFetch).toHaveBeenCalledWith("/api/rooms/1", expect.objectContaining({ method: "DELETE" }));
+		});
+	});
+});
+
+describe("itemApi", () => {
+	const roomId = "room-1";
+
+	describe("list", () => {
+		it("fetches items for a room", async () => {
+			const items = [{ id: "i1", content: "Test" }];
+			mockFetch.mockResolvedValueOnce(mockResponse(items));
+
+			const result = await itemApi.list(roomId);
+			expect(result).toEqual(items);
+		});
+	});
+
+	describe("create", () => {
+		it("creates an item with position", async () => {
+			const newItem = { id: "i1", content: "New item", position_x: 1, position_z: 2 };
+			mockFetch.mockResolvedValueOnce(mockResponse(newItem, 201));
+
+			const result = await itemApi.create(roomId, {
+				content: "New item",
+				position: { x: 1, y: 0, z: 2 },
+			});
+
+			expect(result).toEqual(newItem);
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/items`,
+				expect.objectContaining({
+					method: "POST",
+					body: expect.stringContaining("New item"),
+				}),
+			);
+		});
+	});
+
+	describe("update", () => {
+		it("updates an item", async () => {
+			const updated = { id: "i1", content: "Updated" };
+			mockFetch.mockResolvedValueOnce(mockResponse(updated));
+
+			const result = await itemApi.update(roomId, "i1", { content: "Updated" });
+			expect(result).toEqual(updated);
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes an item", async () => {
+			mockFetch.mockResolvedValueOnce(mockNoContentResponse());
+
+			await itemApi.delete(roomId, "i1");
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/items/i1`,
+				expect.objectContaining({ method: "DELETE" }),
+			);
+		});
+	});
+});
+
+describe("ApiError", () => {
+	it("is thrown on non-OK responses", async () => {
+		mockFetch.mockResolvedValueOnce(mockErrorResponse(404, "Not found"));
+
+		await expect(roomApi.get("nonexistent")).rejects.toThrow(ApiError);
+	});
+
+	it("includes status code and message", async () => {
+		mockFetch.mockResolvedValueOnce(mockErrorResponse(500, "Internal error"));
+
+		try {
+			await roomApi.get("err");
+			expect.unreachable("Should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ApiError);
+			if (err instanceof ApiError) {
+				expect(err.status).toBe(500);
+				expect(err.message).toContain("Internal error");
+			}
+		}
+	});
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,116 @@
+/**
+ * API client for Memory Palace backend.
+ */
+
+import type {
+	MemoryItem,
+	MemoryItemCreateRequest,
+	MemoryItemUpdateRequest,
+	Room,
+	RoomCreateRequest,
+	RoomUpdateRequest,
+} from "@/types/api";
+
+const BASE_URL = "/api";
+
+class ApiError extends Error {
+	constructor(
+		public readonly status: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "ApiError";
+	}
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+	const response = await fetch(`${BASE_URL}${path}`, {
+		headers: {
+			"Content-Type": "application/json",
+			...options?.headers,
+		},
+		...options,
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.text().catch(() => "Unknown error");
+		throw new ApiError(response.status, `API error ${response.status}: ${errorBody}`);
+	}
+
+	// 204 No Content
+	if (response.status === 204) {
+		return undefined as T;
+	}
+
+	return response.json() as Promise<T>;
+}
+
+// =============================================================================
+// Room API
+// =============================================================================
+
+export const roomApi = {
+	list(): Promise<Room[]> {
+		return request<Room[]>("/rooms");
+	},
+
+	get(roomId: string): Promise<Room> {
+		return request<Room>(`/rooms/${roomId}`);
+	},
+
+	create(data: RoomCreateRequest): Promise<Room> {
+		return request<Room>("/rooms", {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	},
+
+	update(roomId: string, data: RoomUpdateRequest): Promise<Room> {
+		return request<Room>(`/rooms/${roomId}`, {
+			method: "PATCH",
+			body: JSON.stringify(data),
+		});
+	},
+
+	delete(roomId: string): Promise<void> {
+		return request<void>(`/rooms/${roomId}`, {
+			method: "DELETE",
+		});
+	},
+};
+
+// =============================================================================
+// MemoryItem API
+// =============================================================================
+
+export const itemApi = {
+	list(roomId: string): Promise<MemoryItem[]> {
+		return request<MemoryItem[]>(`/rooms/${roomId}/items`);
+	},
+
+	get(roomId: string, itemId: string): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items/${itemId}`);
+	},
+
+	create(roomId: string, data: MemoryItemCreateRequest): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items`, {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	},
+
+	update(roomId: string, itemId: string, data: MemoryItemUpdateRequest): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items/${itemId}`, {
+			method: "PATCH",
+			body: JSON.stringify(data),
+		});
+	},
+
+	delete(roomId: string, itemId: string): Promise<void> {
+		return request<void>(`/rooms/${roomId}/items/${itemId}`, {
+			method: "DELETE",
+		});
+	},
+};
+
+export { ApiError };

--- a/frontend/src/lib/roomSerializer.test.ts
+++ b/frontend/src/lib/roomSerializer.test.ts
@@ -1,0 +1,131 @@
+import type { MemoryItem, Room } from "@/types/api";
+import { describe, expect, it } from "vitest";
+import { deserializeRoom, exportRoomJSON, parseRoomJSON, serializeRoom } from "./roomSerializer";
+
+const mockRoom: Room = {
+	id: "room-1",
+	owner_id: "owner-1",
+	name: "Test Room",
+	description: "A test room",
+	layout_data: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockItems: MemoryItem[] = [
+	{
+		id: "item-1",
+		room_id: "room-1",
+		content: "Paris is the capital of France",
+		image_url: null,
+		position_x: 1.5,
+		position_y: 0,
+		position_z: 3.0,
+		ease_factor: 2.5,
+		interval: 1,
+		repetitions: 0,
+		last_reviewed_at: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	},
+	{
+		id: "item-2",
+		room_id: "room-1",
+		content: "Tokyo is the capital of Japan",
+		image_url: "https://example.com/tokyo.png",
+		position_x: -2.0,
+		position_y: 0,
+		position_z: 1.5,
+		ease_factor: 2.5,
+		interval: 1,
+		repetitions: 0,
+		last_reviewed_at: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	},
+];
+
+describe("serializeRoom", () => {
+	it("converts room and items to serialized format", () => {
+		const result = serializeRoom(mockRoom, mockItems);
+
+		expect(result.id).toBe("room-1");
+		expect(result.name).toBe("Test Room");
+		expect(result.description).toBe("A test room");
+		expect(result.items).toHaveLength(2);
+		expect(result.items[0]?.position.x).toBe(1.5);
+		expect(result.items[0]?.position.z).toBe(3.0);
+	});
+
+	it("handles empty items list", () => {
+		const result = serializeRoom(mockRoom, []);
+		expect(result.items).toHaveLength(0);
+	});
+
+	it("preserves image_url in serialized items", () => {
+		const result = serializeRoom(mockRoom, mockItems);
+		expect(result.items[0]?.image_url).toBeNull();
+		expect(result.items[1]?.image_url).toBe("https://example.com/tokyo.png");
+	});
+});
+
+describe("deserializeRoom", () => {
+	it("converts serialized data back to room and items", () => {
+		const serialized = serializeRoom(mockRoom, mockItems);
+		const result = deserializeRoom(serialized);
+
+		expect(result.room.name).toBe("Test Room");
+		expect(result.items).toHaveLength(2);
+		expect(result.items[0]?.content).toBe("Paris is the capital of France");
+	});
+});
+
+describe("exportRoomJSON", () => {
+	it("produces valid JSON string", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const parsed: unknown = JSON.parse(json);
+		expect(parsed).toBeDefined();
+		expect(typeof parsed).toBe("object");
+	});
+
+	it("includes room name and items", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const parsed = JSON.parse(json) as Record<string, unknown>;
+		expect(parsed["name"]).toBe("Test Room");
+		expect(Array.isArray(parsed["items"])).toBe(true);
+	});
+});
+
+describe("parseRoomJSON", () => {
+	it("parses valid room JSON", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const result = parseRoomJSON(json);
+
+		expect(result.name).toBe("Test Room");
+		expect(result.items).toHaveLength(2);
+	});
+
+	it("throws on invalid JSON", () => {
+		expect(() => parseRoomJSON("not json")).toThrow();
+	});
+
+	it("throws on missing name", () => {
+		expect(() => parseRoomJSON('{"items": []}')).toThrow("missing or empty name");
+	});
+
+	it("throws on empty name", () => {
+		expect(() => parseRoomJSON('{"name": "", "items": []}')).toThrow("missing or empty name");
+	});
+
+	it("throws on missing items", () => {
+		expect(() => parseRoomJSON('{"name": "Room"}')).toThrow("items must be an array");
+	});
+
+	it("throws on non-array items", () => {
+		expect(() => parseRoomJSON('{"name": "Room", "items": "not array"}')).toThrow("items must be an array");
+	});
+
+	it("throws on non-object input", () => {
+		expect(() => parseRoomJSON('"just a string"')).toThrow("expected an object");
+	});
+});

--- a/frontend/src/lib/roomSerializer.ts
+++ b/frontend/src/lib/roomSerializer.ts
@@ -1,0 +1,79 @@
+/**
+ * Room data serialization/deserialization utilities.
+ *
+ * Converts between backend API data and Three.js scene representation.
+ */
+
+import type { MemoryItem, Room } from "@/types/api";
+
+/** Serialized room data for JSON export/import */
+export interface SerializedRoom {
+	id: string;
+	name: string;
+	description: string | null;
+	items: SerializedItem[];
+}
+
+export interface SerializedItem {
+	id: string;
+	content: string;
+	position: { x: number; y: number; z: number };
+	image_url: string | null;
+}
+
+/** Convert API room + items to serialized format */
+export function serializeRoom(room: Room, items: MemoryItem[]): SerializedRoom {
+	return {
+		id: room.id,
+		name: room.name,
+		description: room.description,
+		items: items.map((item) => ({
+			id: item.id,
+			content: item.content,
+			position: {
+				x: item.position_x,
+				y: item.position_y,
+				z: item.position_z,
+			},
+			image_url: item.image_url,
+		})),
+	};
+}
+
+/** Convert serialized format back to API-compatible structures */
+export function deserializeRoom(data: SerializedRoom): { room: Partial<Room>; items: SerializedItem[] } {
+	return {
+		room: {
+			id: data.id,
+			name: data.name,
+			description: data.description,
+		},
+		items: data.items,
+	};
+}
+
+/** Export room data as JSON string */
+export function exportRoomJSON(room: Room, items: MemoryItem[]): string {
+	return JSON.stringify(serializeRoom(room, items), null, 2);
+}
+
+/** Parse and validate imported room JSON */
+export function parseRoomJSON(json: string): SerializedRoom {
+	const parsed: unknown = JSON.parse(json);
+
+	if (typeof parsed !== "object" || parsed === null) {
+		throw new Error("Invalid room data: expected an object");
+	}
+
+	const data = parsed as Record<string, unknown>;
+
+	if (typeof data["name"] !== "string" || data["name"].length === 0) {
+		throw new Error("Invalid room data: missing or empty name");
+	}
+
+	if (!Array.isArray(data["items"])) {
+		throw new Error("Invalid room data: items must be an array");
+	}
+
+	return data as unknown as SerializedRoom;
+}

--- a/frontend/src/lib/three/FirstPersonControls.ts
+++ b/frontend/src/lib/three/FirstPersonControls.ts
@@ -1,0 +1,205 @@
+/**
+ * First-person camera controls using PointerLock API.
+ *
+ * WASD movement + mouse look (activated by clicking on the canvas).
+ * Movement is constrained within room boundaries.
+ */
+
+import * as THREE from "three";
+import type { RoomDimensions } from "./RoomScene";
+
+/** Movement speed in units per second */
+const MOVE_SPEED = 5.0;
+
+/** Mouse sensitivity (radians per pixel) */
+const MOUSE_SENSITIVITY = 0.002;
+
+/** Camera height (eye level) */
+const EYE_HEIGHT = 1.6;
+
+/** Margin from walls */
+const WALL_MARGIN = 0.5;
+
+interface KeyState {
+	forward: boolean;
+	backward: boolean;
+	left: boolean;
+	right: boolean;
+}
+
+export class FirstPersonControls {
+	private readonly camera: THREE.PerspectiveCamera;
+	private readonly domElement: HTMLElement;
+	private readonly dimensions: RoomDimensions;
+	private readonly euler: THREE.Euler;
+	private readonly velocity: THREE.Vector3;
+	private readonly direction: THREE.Vector3;
+	private readonly keys: KeyState;
+	private isLocked: boolean;
+	private prevTime: number;
+
+	private readonly onMouseMoveBound: (e: MouseEvent) => void;
+	private readonly onKeyDownBound: (e: KeyboardEvent) => void;
+	private readonly onKeyUpBound: (e: KeyboardEvent) => void;
+	private readonly onPointerLockChangeBound: () => void;
+	private readonly onClickBound: () => void;
+
+	constructor(camera: THREE.PerspectiveCamera, domElement: HTMLElement, dimensions: RoomDimensions) {
+		this.camera = camera;
+		this.domElement = domElement;
+		this.dimensions = dimensions;
+		this.euler = new THREE.Euler(0, 0, 0, "YXZ");
+		this.velocity = new THREE.Vector3();
+		this.direction = new THREE.Vector3();
+		this.keys = { forward: false, backward: false, left: false, right: false };
+		this.isLocked = false;
+		this.prevTime = performance.now();
+
+		this.onMouseMoveBound = this.onMouseMove.bind(this);
+		this.onKeyDownBound = this.onKeyDown.bind(this);
+		this.onKeyUpBound = this.onKeyUp.bind(this);
+		this.onPointerLockChangeBound = this.onPointerLockChange.bind(this);
+		this.onClickBound = this.onClick.bind(this);
+
+		this.connect();
+	}
+
+	private connect(): void {
+		document.addEventListener("mousemove", this.onMouseMoveBound);
+		document.addEventListener("keydown", this.onKeyDownBound);
+		document.addEventListener("keyup", this.onKeyUpBound);
+		document.addEventListener("pointerlockchange", this.onPointerLockChangeBound);
+		this.domElement.addEventListener("click", this.onClickBound);
+	}
+
+	disconnect(): void {
+		document.removeEventListener("mousemove", this.onMouseMoveBound);
+		document.removeEventListener("keydown", this.onKeyDownBound);
+		document.removeEventListener("keyup", this.onKeyUpBound);
+		document.removeEventListener("pointerlockchange", this.onPointerLockChangeBound);
+		this.domElement.removeEventListener("click", this.onClickBound);
+
+		if (document.pointerLockElement === this.domElement) {
+			document.exitPointerLock();
+		}
+	}
+
+	private onClick(): void {
+		this.domElement.requestPointerLock();
+	}
+
+	private onPointerLockChange(): void {
+		this.isLocked = document.pointerLockElement === this.domElement;
+		if (!this.isLocked) {
+			this.keys.forward = false;
+			this.keys.backward = false;
+			this.keys.left = false;
+			this.keys.right = false;
+		}
+	}
+
+	private onMouseMove(event: MouseEvent): void {
+		if (!this.isLocked) return;
+
+		this.euler.setFromQuaternion(this.camera.quaternion);
+		this.euler.y -= event.movementX * MOUSE_SENSITIVITY;
+		this.euler.x -= event.movementY * MOUSE_SENSITIVITY;
+		// Clamp vertical look to prevent flipping
+		this.euler.x = Math.max(-Math.PI / 2 + 0.01, Math.min(Math.PI / 2 - 0.01, this.euler.x));
+
+		this.camera.quaternion.setFromEuler(this.euler);
+	}
+
+	private onKeyDown(event: KeyboardEvent): void {
+		if (!this.isLocked) return;
+
+		switch (event.code) {
+			case "KeyW":
+			case "ArrowUp":
+				this.keys.forward = true;
+				break;
+			case "KeyS":
+			case "ArrowDown":
+				this.keys.backward = true;
+				break;
+			case "KeyA":
+			case "ArrowLeft":
+				this.keys.left = true;
+				break;
+			case "KeyD":
+			case "ArrowRight":
+				this.keys.right = true;
+				break;
+		}
+	}
+
+	private onKeyUp(event: KeyboardEvent): void {
+		switch (event.code) {
+			case "KeyW":
+			case "ArrowUp":
+				this.keys.forward = false;
+				break;
+			case "KeyS":
+			case "ArrowDown":
+				this.keys.backward = false;
+				break;
+			case "KeyA":
+			case "ArrowLeft":
+				this.keys.left = false;
+				break;
+			case "KeyD":
+			case "ArrowRight":
+				this.keys.right = false;
+				break;
+		}
+	}
+
+	/** Update camera position based on key state. Call each frame. */
+	update(): void {
+		const time = performance.now();
+		const delta = (time - this.prevTime) / 1000;
+		this.prevTime = time;
+
+		if (!this.isLocked) return;
+
+		// Apply friction
+		this.velocity.x -= this.velocity.x * 10.0 * delta;
+		this.velocity.z -= this.velocity.z * 10.0 * delta;
+
+		// Calculate direction
+		this.direction.z = Number(this.keys.forward) - Number(this.keys.backward);
+		this.direction.x = Number(this.keys.right) - Number(this.keys.left);
+		this.direction.normalize();
+
+		if (this.keys.forward || this.keys.backward) {
+			this.velocity.z -= this.direction.z * MOVE_SPEED * delta;
+		}
+		if (this.keys.left || this.keys.right) {
+			this.velocity.x -= this.direction.x * MOVE_SPEED * delta;
+		}
+
+		// Move camera
+		const forward = new THREE.Vector3();
+		this.camera.getWorldDirection(forward);
+		forward.y = 0;
+		forward.normalize();
+
+		const right = new THREE.Vector3();
+		right.crossVectors(this.camera.up, forward).normalize();
+
+		this.camera.position.addScaledVector(forward, -this.velocity.z * delta);
+		this.camera.position.addScaledVector(right, -this.velocity.x * delta);
+
+		// Constrain to room boundaries
+		const halfWidth = this.dimensions.width / 2 - WALL_MARGIN;
+		const halfDepth = this.dimensions.depth / 2 - WALL_MARGIN;
+		this.camera.position.x = Math.max(-halfWidth, Math.min(halfWidth, this.camera.position.x));
+		this.camera.position.z = Math.max(-halfDepth, Math.min(halfDepth, this.camera.position.z));
+		this.camera.position.y = EYE_HEIGHT;
+	}
+
+	/** Check if pointer is currently locked */
+	getIsLocked(): boolean {
+		return this.isLocked;
+	}
+}

--- a/frontend/src/lib/three/ItemManager.ts
+++ b/frontend/src/lib/three/ItemManager.ts
@@ -1,0 +1,416 @@
+/**
+ * Manages 3D memory item objects in the room scene.
+ *
+ * Handles creation, selection, movement, and deletion of item markers.
+ * Uses Raycaster for click-based interaction.
+ */
+
+import * as THREE from "three";
+import type { RoomDimensions } from "./RoomScene";
+
+/** Visual representation of a memory item in 3D space */
+export interface Item3D {
+	id: string;
+	content: string;
+	mesh: THREE.Mesh;
+	label: THREE.Sprite;
+	group: THREE.Group;
+}
+
+/** Callback types for item events */
+export interface ItemManagerCallbacks {
+	onItemPlaced?: (position: THREE.Vector3) => void;
+	onItemSelected?: (itemId: string) => void;
+	onItemDeselected?: () => void;
+}
+
+/** Item marker geometry constants */
+const MARKER_RADIUS = 0.2;
+const MARKER_HEIGHT = 0.5;
+const MARKER_SEGMENTS = 8;
+const LABEL_SCALE = 0.8;
+const LABEL_Y_OFFSET = 0.8;
+
+/** Colors */
+const COLOR_DEFAULT = 0x00aaff;
+const COLOR_SELECTED = 0xffaa00;
+const COLOR_HOVER = 0x44ccff;
+
+export class ItemManager {
+	private readonly scene: THREE.Scene;
+	private readonly camera: THREE.PerspectiveCamera;
+	private readonly raycaster: THREE.Raycaster;
+	private readonly mouse: THREE.Vector2;
+	private readonly dimensions: RoomDimensions;
+	private readonly items: Map<string, Item3D>;
+	private readonly callbacks: ItemManagerCallbacks;
+
+	private selectedItemId: string | null = null;
+	private hoveredItemId: string | null = null;
+	private placementMode = false;
+
+	/** Placement indicator (crosshair on the floor) */
+	private readonly placementIndicator: THREE.Mesh;
+
+	constructor(
+		scene: THREE.Scene,
+		camera: THREE.PerspectiveCamera,
+		dimensions: RoomDimensions,
+		callbacks: ItemManagerCallbacks = {},
+	) {
+		this.scene = scene;
+		this.camera = camera;
+		this.raycaster = new THREE.Raycaster();
+		this.mouse = new THREE.Vector2();
+		this.dimensions = dimensions;
+		this.items = new Map();
+		this.callbacks = callbacks;
+
+		// Create placement indicator (hidden by default)
+		const indicatorGeo = new THREE.RingGeometry(0.15, 0.25, 16);
+		const indicatorMat = new THREE.MeshBasicMaterial({
+			color: 0x00ff88,
+			side: THREE.DoubleSide,
+			transparent: true,
+			opacity: 0.7,
+		});
+		this.placementIndicator = new THREE.Mesh(indicatorGeo, indicatorMat);
+		this.placementIndicator.rotation.x = -Math.PI / 2;
+		this.placementIndicator.visible = false;
+		this.scene.add(this.placementIndicator);
+	}
+
+	/** Add a memory item to the scene */
+	addItem(id: string, content: string, position: THREE.Vector3): Item3D {
+		const group = new THREE.Group();
+		group.position.copy(position);
+
+		// Marker mesh (cylinder with sphere on top)
+		const markerGeo = new THREE.CylinderGeometry(MARKER_RADIUS * 0.5, MARKER_RADIUS, MARKER_HEIGHT, MARKER_SEGMENTS);
+		const markerMat = new THREE.MeshStandardMaterial({
+			color: COLOR_DEFAULT,
+			emissive: COLOR_DEFAULT,
+			emissiveIntensity: 0.3,
+			roughness: 0.4,
+			metalness: 0.6,
+		});
+		const mesh = new THREE.Mesh(markerGeo, markerMat);
+		mesh.position.y = MARKER_HEIGHT / 2;
+		mesh.castShadow = true;
+		mesh.userData["itemId"] = id;
+		group.add(mesh);
+
+		// Sphere top cap
+		const sphereGeo = new THREE.SphereGeometry(MARKER_RADIUS * 0.6, MARKER_SEGMENTS, MARKER_SEGMENTS);
+		const sphere = new THREE.Mesh(sphereGeo, markerMat);
+		sphere.position.y = MARKER_HEIGHT;
+		sphere.castShadow = true;
+		sphere.userData["itemId"] = id;
+		group.add(sphere);
+
+		// Text label sprite
+		const label = this.createLabelSprite(content);
+		label.position.y = MARKER_HEIGHT + LABEL_Y_OFFSET;
+		group.add(label);
+
+		this.scene.add(group);
+
+		const item3D: Item3D = { id, content, mesh, label, group };
+		this.items.set(id, item3D);
+		return item3D;
+	}
+
+	/** Remove a memory item from the scene */
+	removeItem(id: string): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		if (this.selectedItemId === id) {
+			this.selectedItemId = null;
+			this.callbacks.onItemDeselected?.();
+		}
+
+		this.scene.remove(item.group);
+
+		// Dispose geometries and materials
+		item.group.traverse((child) => {
+			if (child instanceof THREE.Mesh) {
+				child.geometry.dispose();
+				if (Array.isArray(child.material)) {
+					for (const mat of child.material) {
+						mat.dispose();
+					}
+				} else {
+					child.material.dispose();
+				}
+			}
+			if (child instanceof THREE.Sprite) {
+				child.material.map?.dispose();
+				child.material.dispose();
+			}
+		});
+
+		this.items.delete(id);
+		return true;
+	}
+
+	/** Update item position */
+	moveItem(id: string, position: THREE.Vector3): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		const clampedPos = this.clampToRoom(position);
+		item.group.position.copy(clampedPos);
+		return true;
+	}
+
+	/** Update item label text */
+	updateItemContent(id: string, content: string): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		// Remove old label
+		item.group.remove(item.label);
+		item.label.material.map?.dispose();
+		item.label.material.dispose();
+
+		// Create new label
+		const newLabel = this.createLabelSprite(content);
+		newLabel.position.y = MARKER_HEIGHT + LABEL_Y_OFFSET;
+		item.group.add(newLabel);
+		item.label = newLabel;
+		item.content = content;
+
+		return true;
+	}
+
+	/** Handle mouse move for hover effects and placement indicator */
+	handleMouseMove(event: MouseEvent, canvasRect: DOMRect): void {
+		this.mouse.x = ((event.clientX - canvasRect.left) / canvasRect.width) * 2 - 1;
+		this.mouse.y = -((event.clientY - canvasRect.top) / canvasRect.height) * 2 + 1;
+
+		if (this.placementMode) {
+			this.updatePlacementIndicator();
+		} else {
+			this.updateHover();
+		}
+	}
+
+	/** Handle click for item selection or placement */
+	handleClick(event: MouseEvent, canvasRect: DOMRect): void {
+		this.mouse.x = ((event.clientX - canvasRect.left) / canvasRect.width) * 2 - 1;
+		this.mouse.y = -((event.clientY - canvasRect.top) / canvasRect.height) * 2 + 1;
+
+		if (this.placementMode) {
+			this.handlePlacement();
+			return;
+		}
+
+		this.handleSelection();
+	}
+
+	/** Toggle placement mode */
+	setPlacementMode(enabled: boolean): void {
+		this.placementMode = enabled;
+		this.placementIndicator.visible = false;
+
+		if (enabled && this.selectedItemId) {
+			this.deselectItem();
+		}
+	}
+
+	/** Get whether in placement mode */
+	isInPlacementMode(): boolean {
+		return this.placementMode;
+	}
+
+	/** Get currently selected item ID */
+	getSelectedItemId(): string | null {
+		return this.selectedItemId;
+	}
+
+	/** Get all items */
+	getAllItems(): ReadonlyMap<string, Item3D> {
+		return this.items;
+	}
+
+	/** Get item position */
+	getItemPosition(id: string): THREE.Vector3 | null {
+		const item = this.items.get(id);
+		return item ? item.group.position.clone() : null;
+	}
+
+	/** Dispose all resources */
+	dispose(): void {
+		for (const [id] of this.items) {
+			this.removeItem(id);
+		}
+		this.placementIndicator.geometry.dispose();
+		if (this.placementIndicator.material instanceof THREE.Material) {
+			this.placementIndicator.material.dispose();
+		}
+	}
+
+	// =========================================================================
+	// Private methods
+	// =========================================================================
+
+	private createLabelSprite(text: string): THREE.Sprite {
+		const canvas = document.createElement("canvas");
+		const ctx = canvas.getContext("2d");
+		if (!ctx) {
+			throw new Error("Failed to create 2D canvas context for label");
+		}
+
+		canvas.width = 256;
+		canvas.height = 64;
+
+		// Background
+		ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
+		ctx.roundRect(0, 0, canvas.width, canvas.height, 8);
+		ctx.fill();
+
+		// Text (truncate to fit)
+		ctx.fillStyle = "#ffffff";
+		ctx.font = "bold 20px sans-serif";
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+
+		const displayText = text.length > 25 ? `${text.substring(0, 22)}...` : text;
+		ctx.fillText(displayText, canvas.width / 2, canvas.height / 2);
+
+		const texture = new THREE.CanvasTexture(canvas);
+		const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+		const sprite = new THREE.Sprite(material);
+		sprite.scale.set(LABEL_SCALE * (canvas.width / canvas.height), LABEL_SCALE, 1);
+
+		return sprite;
+	}
+
+	private getFloorIntersection(): THREE.Vector3 | null {
+		this.raycaster.setFromCamera(this.mouse, this.camera);
+
+		// Intersect with the floor plane (y = 0)
+		const floorPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+		const target = new THREE.Vector3();
+		const hit = this.raycaster.ray.intersectPlane(floorPlane, target);
+
+		if (!hit) return null;
+		return this.clampToRoom(target);
+	}
+
+	private getItemIntersection(): string | null {
+		this.raycaster.setFromCamera(this.mouse, this.camera);
+
+		const meshes: THREE.Object3D[] = [];
+		for (const item of this.items.values()) {
+			item.group.traverse((child) => {
+				if (child instanceof THREE.Mesh) {
+					meshes.push(child);
+				}
+			});
+		}
+
+		const intersects = this.raycaster.intersectObjects(meshes);
+		if (intersects.length > 0) {
+			const hitObject = intersects[0]?.object;
+			const itemId = hitObject?.userData?.["itemId"] as string | undefined;
+			return itemId ?? null;
+		}
+		return null;
+	}
+
+	private updatePlacementIndicator(): void {
+		const point = this.getFloorIntersection();
+		if (point) {
+			this.placementIndicator.position.set(point.x, 0.02, point.z);
+			this.placementIndicator.visible = true;
+		} else {
+			this.placementIndicator.visible = false;
+		}
+	}
+
+	private updateHover(): void {
+		const hitId = this.getItemIntersection();
+
+		// Unhover previous
+		if (this.hoveredItemId && this.hoveredItemId !== hitId) {
+			const prev = this.items.get(this.hoveredItemId);
+			if (prev && this.hoveredItemId !== this.selectedItemId) {
+				this.setItemColor(prev, COLOR_DEFAULT);
+			}
+			this.hoveredItemId = null;
+		}
+
+		// Hover new
+		if (hitId && hitId !== this.selectedItemId) {
+			const item = this.items.get(hitId);
+			if (item) {
+				this.setItemColor(item, COLOR_HOVER);
+				this.hoveredItemId = hitId;
+			}
+		}
+	}
+
+	private handlePlacement(): void {
+		const point = this.getFloorIntersection();
+		if (point) {
+			this.placementMode = false;
+			this.placementIndicator.visible = false;
+			this.callbacks.onItemPlaced?.(point);
+		}
+	}
+
+	private handleSelection(): void {
+		const hitId = this.getItemIntersection();
+
+		if (hitId) {
+			// Select item
+			if (this.selectedItemId && this.selectedItemId !== hitId) {
+				this.deselectItem();
+			}
+			const item = this.items.get(hitId);
+			if (item) {
+				this.selectedItemId = hitId;
+				this.setItemColor(item, COLOR_SELECTED);
+				this.callbacks.onItemSelected?.(hitId);
+			}
+		} else if (this.selectedItemId) {
+			// Deselect
+			this.deselectItem();
+		}
+	}
+
+	private deselectItem(): void {
+		if (this.selectedItemId) {
+			const item = this.items.get(this.selectedItemId);
+			if (item) {
+				this.setItemColor(item, COLOR_DEFAULT);
+			}
+			this.selectedItemId = null;
+			this.callbacks.onItemDeselected?.();
+		}
+	}
+
+	private setItemColor(item: Item3D, color: number): void {
+		item.group.traverse((child) => {
+			if (child instanceof THREE.Mesh) {
+				const mat = child.material;
+				if (mat instanceof THREE.MeshStandardMaterial) {
+					mat.color.setHex(color);
+					mat.emissive.setHex(color);
+				}
+			}
+		});
+	}
+
+	private clampToRoom(position: THREE.Vector3): THREE.Vector3 {
+		const halfWidth = this.dimensions.width / 2 - 0.3;
+		const halfDepth = this.dimensions.depth / 2 - 0.3;
+		return new THREE.Vector3(
+			Math.max(-halfWidth, Math.min(halfWidth, position.x)),
+			0,
+			Math.max(-halfDepth, Math.min(halfDepth, position.z)),
+		);
+	}
+}

--- a/frontend/src/lib/three/RoomScene.ts
+++ b/frontend/src/lib/three/RoomScene.ts
@@ -1,0 +1,179 @@
+/**
+ * Three.js room scene manager.
+ *
+ * Handles renderer, camera, scene, lighting, and room geometry.
+ * Designed for first-person navigation using PointerLockControls-like behavior.
+ */
+
+import * as THREE from "three";
+
+/** Room geometry dimensions */
+export interface RoomDimensions {
+	width: number;
+	height: number;
+	depth: number;
+}
+
+/** Default room dimensions */
+const DEFAULT_DIMENSIONS: RoomDimensions = {
+	width: 20,
+	height: 4,
+	depth: 20,
+};
+
+export class RoomScene {
+	readonly scene: THREE.Scene;
+	readonly camera: THREE.PerspectiveCamera;
+	readonly renderer: THREE.WebGLRenderer;
+
+	private animationId: number | null = null;
+	private readonly dimensions: RoomDimensions;
+
+	constructor(canvas: HTMLCanvasElement, dimensions?: Partial<RoomDimensions>) {
+		this.dimensions = { ...DEFAULT_DIMENSIONS, ...dimensions };
+
+		// Scene
+		this.scene = new THREE.Scene();
+		this.scene.background = new THREE.Color(0x1a1a2e);
+		this.scene.fog = new THREE.Fog(0x1a1a2e, 15, 35);
+
+		// Camera
+		this.camera = new THREE.PerspectiveCamera(70, canvas.clientWidth / canvas.clientHeight, 0.1, 100);
+		this.camera.position.set(0, 1.6, this.dimensions.depth / 2 - 1);
+
+		// Renderer
+		this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+		this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+		this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+		this.renderer.shadowMap.enabled = true;
+		this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+		this.setupLighting();
+		this.buildRoom();
+	}
+
+	private setupLighting(): void {
+		// Ambient
+		const ambient = new THREE.AmbientLight(0x404060, 0.6);
+		this.scene.add(ambient);
+
+		// Main directional light
+		const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+		directional.position.set(5, this.dimensions.height - 0.5, 5);
+		directional.castShadow = true;
+		directional.shadow.mapSize.width = 1024;
+		directional.shadow.mapSize.height = 1024;
+		this.scene.add(directional);
+
+		// Fill light
+		const fill = new THREE.PointLight(0x8888ff, 0.3, 30);
+		fill.position.set(-3, this.dimensions.height - 1, -3);
+		this.scene.add(fill);
+	}
+
+	private buildRoom(): void {
+		const { width, height, depth } = this.dimensions;
+
+		// Floor
+		const floorGeometry = new THREE.PlaneGeometry(width, depth);
+		const floorMaterial = new THREE.MeshStandardMaterial({
+			color: 0x2a2a4a,
+			roughness: 0.8,
+			metalness: 0.2,
+		});
+		const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+		floor.rotation.x = -Math.PI / 2;
+		floor.receiveShadow = true;
+		floor.userData["type"] = "floor";
+		this.scene.add(floor);
+
+		// Grid helper on floor
+		const grid = new THREE.GridHelper(width, width, 0x444466, 0x333355);
+		grid.position.y = 0.01;
+		this.scene.add(grid);
+
+		// Walls
+		const wallMaterial = new THREE.MeshStandardMaterial({
+			color: 0x3a3a5c,
+			roughness: 0.9,
+			metalness: 0.1,
+			side: THREE.DoubleSide,
+		});
+
+		// Back wall
+		const backWall = new THREE.Mesh(new THREE.PlaneGeometry(width, height), wallMaterial);
+		backWall.position.set(0, height / 2, -depth / 2);
+		backWall.receiveShadow = true;
+		this.scene.add(backWall);
+
+		// Front wall
+		const frontWall = new THREE.Mesh(new THREE.PlaneGeometry(width, height), wallMaterial);
+		frontWall.position.set(0, height / 2, depth / 2);
+		frontWall.rotation.y = Math.PI;
+		frontWall.receiveShadow = true;
+		this.scene.add(frontWall);
+
+		// Left wall
+		const leftWall = new THREE.Mesh(new THREE.PlaneGeometry(depth, height), wallMaterial);
+		leftWall.position.set(-width / 2, height / 2, 0);
+		leftWall.rotation.y = Math.PI / 2;
+		leftWall.receiveShadow = true;
+		this.scene.add(leftWall);
+
+		// Right wall
+		const rightWall = new THREE.Mesh(new THREE.PlaneGeometry(depth, height), wallMaterial);
+		rightWall.position.set(width / 2, height / 2, 0);
+		rightWall.rotation.y = -Math.PI / 2;
+		rightWall.receiveShadow = true;
+		this.scene.add(rightWall);
+	}
+
+	/** Start the render loop */
+	start(onFrame?: () => void): void {
+		const animate = (): void => {
+			this.animationId = requestAnimationFrame(animate);
+			onFrame?.();
+			this.renderer.render(this.scene, this.camera);
+		};
+		animate();
+	}
+
+	/** Stop the render loop */
+	stop(): void {
+		if (this.animationId !== null) {
+			cancelAnimationFrame(this.animationId);
+			this.animationId = null;
+		}
+	}
+
+	/** Handle window resize */
+	handleResize(width: number, height: number): void {
+		this.camera.aspect = width / height;
+		this.camera.updateProjectionMatrix();
+		this.renderer.setSize(width, height);
+	}
+
+	/** Get the room dimensions */
+	getDimensions(): Readonly<RoomDimensions> {
+		return { ...this.dimensions };
+	}
+
+	/** Dispose of all Three.js resources */
+	dispose(): void {
+		this.stop();
+		this.scene.traverse((object) => {
+			if (object instanceof THREE.Mesh) {
+				object.geometry.dispose();
+				const material = object.material;
+				if (Array.isArray(material)) {
+					for (const mat of material) {
+						mat.dispose();
+					}
+				} else {
+					material.dispose();
+				}
+			}
+		});
+		this.renderer.dispose();
+	}
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,59 @@
+/**
+ * API response types matching the backend Pydantic schemas.
+ */
+
+export interface Position {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface Room {
+	id: string;
+	owner_id: string;
+	name: string;
+	description: string | null;
+	layout_data: Record<string, unknown> | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface RoomCreateRequest {
+	name: string;
+	description?: string | null;
+	layout_data?: Record<string, unknown> | null;
+}
+
+export interface RoomUpdateRequest {
+	name?: string;
+	description?: string | null;
+	layout_data?: Record<string, unknown> | null;
+}
+
+export interface MemoryItem {
+	id: string;
+	room_id: string;
+	content: string;
+	image_url: string | null;
+	position_x: number;
+	position_y: number;
+	position_z: number;
+	ease_factor: number;
+	interval: number;
+	repetitions: number;
+	last_reviewed_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MemoryItemCreateRequest {
+	content: string;
+	image_url?: string | null;
+	position: Position;
+}
+
+export interface MemoryItemUpdateRequest {
+	content?: string;
+	image_url?: string | null;
+	position?: Position;
+}


### PR DESCRIPTION
## Summary
- Room/MemoryItem CRUD REST API（FastAPI）を実装。ルーム作成、取得、更新、削除 + ルーム内アイテムの配置・移動・削除を完全サポート
- Three.js ベースの3Dルームシーン（床、壁、ライティング、フォグ）、一人称視点カメラ操作（WASD + マウス）、アイテム3D配置・選択・ホバーエフェクトを実装
- SQLAlchemy の UUID カラム型を `Uuid` に統一し、SQLite テスト互換性を修正

## 変更内容

### バックエンド
- `backend/src/memory_palace/api/rooms.py`: Room CRUD + MemoryItem CRUD API（10エンドポイント）
- モデル UUID 型を `sqlalchemy.Uuid` に統一（`UUID(as_uuid=True)` → `Uuid`）
- `pyproject.toml`: API ファイルの B008 リントルール除外追加
- テスト 32 件追加（`test_rooms_api.py`）、API カバレッジ 100%

### フロントエンド
- `RoomScene.ts`: Three.js シーン（renderer, camera, scene, lighting, room geometry）
- `FirstPersonControls.ts`: PointerLock + WASD 一人称視点操作、壁境界制限
- `ItemManager.ts`: Raycaster ベースのアイテム配置、選択、移動、削除、ラベルスプライト
- `RoomEditor.tsx`: React + Three.js 統合コンポーネント
- `api.ts`: API クライアント（roomApi, itemApi）
- `roomSerializer.ts`: ルームデータの JSON シリアライズ/デシリアライズ
- `App.tsx`: ルーム一覧 + エディタ画面遷移
- テスト 32 件追加（API, serializer, App）

## Test plan
- [x] `make check` 全パス（format, lint, typecheck, test, build）
- [x] バックエンド 110 テスト全パス、カバレッジ 95%
- [x] フロントエンド 32 テスト全パス
- [ ] 手動テスト: ルーム作成 → 3D空間描画 → アイテム配置 → 移動 → 削除
- [ ] 60fps パフォーマンス確認（DevTools Performance パネル）

Closes #8