### PR TITLE
feat #11: 復習UI + 統計ダッシュボード（正答率トラッキング・忘却曲線可視化）

### DIFF
--- a/backend/alembic.ini
+++ b/backend/alembic.ini
@@ -1,0 +1,152 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+# Also add src directory so models can be imported
+# prepend_sys_path = .:src
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# Database URL is set dynamically via DATABASE_URL env var in env.py
+# sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/alembic/README
+++ b/backend/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,0 +1,82 @@
+"""Alembic migration environment configuration."""
+
+from __future__ import annotations
+
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from sqlalchemy import engine_from_config, pool
+
+from alembic import context
+
+# Add the src directory to the Python path so models can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from memory_palace.database import Base
+from memory_palace.models import *  # noqa: F403
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Override sqlalchemy.url from DATABASE_URL environment variable
+database_url = os.environ.get("DATABASE_URL", "")
+if database_url:
+    config.set_main_option("sqlalchemy.url", database_url)
+
+# Interpret the config file for Python logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# Set target metadata for autogenerate support
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/alembic/script.py.mako
+++ b/backend/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/backend/alembic/versions/001_initial_schema_users_rooms_memory_items_.py
+++ b/backend/alembic/versions/001_initial_schema_users_rooms_memory_items_.py
@@ -1,0 +1,114 @@
+"""initial schema: users, rooms, memory_items, review_sessions, review_records
+
+Revision ID: 001
+Revises:
+Create Date: 2026-03-30 12:39:33.128201
+
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "001"
+down_revision: str | None = None
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    """Create initial tables: users, rooms, memory_items, review_sessions, review_records."""
+    # --- users ---
+    op.create_table(
+        "users",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("username", sa.String(100), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("password_hash", sa.String(255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("username"),
+        sa.UniqueConstraint("email"),
+    )
+    op.create_index("ix_users_username", "users", ["username"])
+    op.create_index("ix_users_email", "users", ["email"])
+
+    # --- rooms ---
+    op.create_table(
+        "rooms",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("owner_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("layout_data", postgresql.JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["owner_id"], ["users.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_rooms_owner_id", "rooms", ["owner_id"])
+
+    # --- memory_items ---
+    op.create_table(
+        "memory_items",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("room_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("image_url", sa.String(2048), nullable=True),
+        sa.Column("position_x", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("position_y", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("position_z", sa.Float(), nullable=False, server_default="0.0"),
+        sa.Column("ease_factor", sa.Float(), nullable=False, server_default="2.5"),
+        sa.Column("interval", sa.Integer(), nullable=False, server_default="1"),
+        sa.Column("repetitions", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("last_reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_memory_items_room_id", "memory_items", ["room_id"])
+
+    # --- review_sessions ---
+    op.create_table(
+        "review_sessions",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("room_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("total_items", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completed_items", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["room_id"], ["rooms.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_review_sessions_room_id", "review_sessions", ["room_id"])
+
+    # --- review_records ---
+    op.create_table(
+        "review_records",
+        sa.Column("id", sa.Uuid(), nullable=False, default=sa.text("gen_random_uuid()")),
+        sa.Column("session_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("memory_item_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("quality", sa.Integer(), nullable=False),
+        sa.Column("response_time_ms", sa.Integer(), nullable=False),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["session_id"], ["review_sessions.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["memory_item_id"], ["memory_items.id"], ondelete="CASCADE"),
+    )
+    op.create_index("ix_review_records_session_id", "review_records", ["session_id"])
+    op.create_index("ix_review_records_memory_item_id", "review_records", ["memory_item_id"])
+
+
+def downgrade() -> None:
+    """Drop all tables in reverse order."""
+    op.drop_table("review_records")
+    op.drop_table("review_sessions")
+    op.drop_table("memory_items")
+    op.drop_table("rooms")
+    op.drop_table("users")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "sqlalchemy>=2.0",
     "psycopg[binary]>=3.2",
     "pydantic>=2.10",
+    "alembic>=1.14",
 ]
 
 [project.optional-dependencies]
@@ -100,9 +101,21 @@ max-branches = 12
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = [
     "S101",    # assert 許可
+    "S105",    # hardcoded password（テストデータ）
+    "S106",    # hardcoded password（テストデータ）
     "ANN",     # テストの型注釈は任意
     "ARG",     # fixture の未使用引数
     "PLR2004", # マジックナンバー許可
+]
+"src/**/models/**/*.py" = [
+    "TCH003",  # SQLAlchemy Mapped はランタイムで型解決が必要
+]
+"src/**/schemas/**/*.py" = [
+    "TCH003",  # Pydantic BaseModel はランタイムで型解決が必要
+]
+"alembic/**/*.py" = [
+    "ANN",     # マイグレーションの型注釈は任意
+    "ERA001",  # コメントアウトコード許可
 ]
 
 [tool.ruff.format]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -115,6 +115,7 @@ max-branches = 12
 ]
 "src/**/api/**/*.py" = [
     "B008",    # FastAPI Depends() は引数デフォルトとして呼び出す必要がある
+    "TC003",   # FastAPI はパスパラメータ型をランタイムで解決するため uuid 等が必要
 ]
 "alembic/**/*.py" = [
     "ANN",     # マイグレーションの型注釈は任意

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -113,6 +113,9 @@ max-branches = 12
 "src/**/schemas/**/*.py" = [
     "TCH003",  # Pydantic BaseModel はランタイムで型解決が必要
 ]
+"src/**/api/**/*.py" = [
+    "B008",    # FastAPI Depends() は引数デフォルトとして呼び出す必要がある
+]
 "alembic/**/*.py" = [
     "ANN",     # マイグレーションの型注釈は任意
     "ERA001",  # コメントアウトコード許可

--- a/backend/src/memory_palace/api/reviews.py
+++ b/backend/src/memory_palace/api/reviews.py
@@ -5,18 +5,26 @@ from __future__ import annotations
 import uuid
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import select
 
 from memory_palace.database import get_db
 from memory_palace.models.room import Room
 from memory_palace.schemas.memory_item import MemoryItemResponse
 from memory_palace.schemas.review import (
+    DailyStatsResponse,
+    ForgettingCurveResponse,
     ReviewRecordCreate,
     ReviewRecordResponse,
     RoomStatsResponse,
 )
-from memory_palace.services.review import get_review_queue, get_room_stats, record_review
+from memory_palace.services.review import (
+    get_daily_stats,
+    get_forgetting_curves,
+    get_review_queue,
+    get_room_stats,
+    record_review,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -92,3 +100,34 @@ def get_stats(
     """Get review statistics for a room."""
     _get_room_or_404(db, room_id)
     return get_room_stats(db, room_id)
+
+
+@router.get(
+    "/{room_id}/stats/daily",
+    response_model=DailyStatsResponse,
+    summary="Get daily review statistics",
+    description="Returns daily review counts and accuracy rates for chart rendering.",
+)
+def get_daily_stats_endpoint(
+    room_id: uuid.UUID,
+    days: int = Query(default=30, ge=1, le=365, description="Number of days to look back (1-365)"),
+    db: Session = Depends(get_db),
+) -> dict:
+    """Get daily review statistics for a room."""
+    _get_room_or_404(db, room_id)
+    return get_daily_stats(db, room_id, days)
+
+
+@router.get(
+    "/{room_id}/stats/forgetting-curve",
+    response_model=ForgettingCurveResponse,
+    summary="Get forgetting curve data",
+    description="Returns predicted forgetting curves for reviewed items using R(t) = e^(-t/S).",
+)
+def get_forgetting_curve_endpoint(
+    room_id: uuid.UUID,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Get forgetting curve data for a room's items."""
+    _get_room_or_404(db, room_id)
+    return get_forgetting_curves(db, room_id)

--- a/backend/src/memory_palace/api/reviews.py
+++ b/backend/src/memory_palace/api/reviews.py
@@ -1,0 +1,94 @@
+"""Review API endpoints: review queue, review recording, and room statistics."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+
+from memory_palace.database import get_db
+from memory_palace.models.room import Room
+from memory_palace.schemas.memory_item import MemoryItemResponse
+from memory_palace.schemas.review import (
+    ReviewRecordCreate,
+    ReviewRecordResponse,
+    RoomStatsResponse,
+)
+from memory_palace.services.review import get_review_queue, get_room_stats, record_review
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/rooms", tags=["reviews"])
+
+
+def _get_room_or_404(db: Session, room_id: uuid.UUID) -> Room:
+    """Retrieve a room by ID or raise 404."""
+    room = db.execute(select(Room).where(Room.id == room_id)).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Room {room_id} not found",
+        )
+    return room
+
+
+@router.get(
+    "/{room_id}/review-queue",
+    response_model=list[MemoryItemResponse],
+    summary="Get review queue",
+    description="Returns memory items due for review, sorted by urgency.",
+)
+def get_review_queue_endpoint(
+    room_id: uuid.UUID,
+    db: Session = Depends(get_db),
+) -> list:
+    """Get memory items due for review in a room."""
+    _get_room_or_404(db, room_id)
+    return get_review_queue(db, room_id)
+
+
+@router.post(
+    "/{room_id}/review",
+    response_model=ReviewRecordResponse,
+    status_code=status.HTTP_201_CREATED,
+    summary="Record a review result",
+    description="Records a review result and updates SM-2 parameters on the memory item.",
+)
+def post_review(
+    room_id: uuid.UUID,
+    body: ReviewRecordCreate,
+    db: Session = Depends(get_db),
+) -> object:
+    """Record a review result for a memory item."""
+    _get_room_or_404(db, room_id)
+    try:
+        return record_review(
+            db=db,
+            room_id=room_id,
+            memory_item_id=body.memory_item_id,
+            quality=body.quality,
+            response_time_ms=body.response_time_ms,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        ) from e
+
+
+@router.get(
+    "/{room_id}/stats",
+    response_model=RoomStatsResponse,
+    summary="Get room review statistics",
+    description="Returns review statistics for a room including mastery levels and review counts.",
+)
+def get_stats(
+    room_id: uuid.UUID,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Get review statistics for a room."""
+    _get_room_or_404(db, room_id)
+    return get_room_stats(db, room_id)

--- a/backend/src/memory_palace/api/rooms.py
+++ b/backend/src/memory_palace/api/rooms.py
@@ -1,0 +1,187 @@
+"""Room CRUD API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+
+from memory_palace.database import get_db
+from memory_palace.models.memory_item import MemoryItem
+from memory_palace.models.room import Room
+from memory_palace.schemas.memory_item import (
+    MemoryItemCreate,
+    MemoryItemResponse,
+    MemoryItemUpdate,
+)
+from memory_palace.schemas.room import RoomCreate, RoomResponse, RoomUpdate
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+router = APIRouter(prefix="/api/rooms", tags=["rooms"])
+
+
+def _get_room_or_404(db: Session, room_id: uuid.UUID) -> Room:
+    """Retrieve a room by ID or raise 404."""
+    room = db.execute(select(Room).where(Room.id == room_id)).scalar_one_or_none()
+    if room is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Room {room_id} not found",
+        )
+    return room
+
+
+def _get_item_or_404(db: Session, item_id: uuid.UUID, room_id: uuid.UUID) -> MemoryItem:
+    """Retrieve a memory item by ID within a room or raise 404."""
+    item = db.execute(
+        select(MemoryItem).where(
+            MemoryItem.id == item_id,
+            MemoryItem.room_id == room_id,
+        )
+    ).scalar_one_or_none()
+    if item is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"MemoryItem {item_id} not found in room {room_id}",
+        )
+    return item
+
+
+# =============================================================================
+# Room CRUD
+# =============================================================================
+
+
+@router.get("", response_model=list[RoomResponse])
+def list_rooms(db: Session = Depends(get_db)) -> list[Room]:
+    """List all rooms.
+
+    Note: MVP does not implement auth. Owner filtering will be added later.
+    """
+    return list(db.execute(select(Room).order_by(Room.created_at.desc())).scalars().all())
+
+
+@router.post("", response_model=RoomResponse, status_code=status.HTTP_201_CREATED)
+def create_room(body: RoomCreate, db: Session = Depends(get_db)) -> Room:
+    """Create a new room.
+
+    Note: MVP uses a hardcoded owner_id. Auth will be added later.
+    """
+    # MVP: use a deterministic dummy owner id until auth is implemented
+    dummy_owner_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    room = Room(
+        owner_id=dummy_owner_id,
+        name=body.name,
+        description=body.description,
+        layout_data=body.layout_data,
+    )
+    db.add(room)
+    db.commit()
+    db.refresh(room)
+    return room
+
+
+@router.get("/{room_id}", response_model=RoomResponse)
+def get_room(room_id: uuid.UUID, db: Session = Depends(get_db)) -> Room:
+    """Get a room by ID."""
+    return _get_room_or_404(db, room_id)
+
+
+@router.patch("/{room_id}", response_model=RoomResponse)
+def update_room(room_id: uuid.UUID, body: RoomUpdate, db: Session = Depends(get_db)) -> Room:
+    """Update a room."""
+    room = _get_room_or_404(db, room_id)
+    update_data = body.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(room, key, value)
+    db.commit()
+    db.refresh(room)
+    return room
+
+
+@router.delete("/{room_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_room(room_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a room and all its memory items (cascade)."""
+    room = _get_room_or_404(db, room_id)
+    db.delete(room)
+    db.commit()
+
+
+# =============================================================================
+# MemoryItem CRUD (nested under rooms)
+# =============================================================================
+
+
+@router.get("/{room_id}/items", response_model=list[MemoryItemResponse])
+def list_items(room_id: uuid.UUID, db: Session = Depends(get_db)) -> list[MemoryItem]:
+    """List all memory items in a room."""
+    _get_room_or_404(db, room_id)
+    return list(
+        db.execute(select(MemoryItem).where(MemoryItem.room_id == room_id).order_by(MemoryItem.created_at))
+        .scalars()
+        .all()
+    )
+
+
+@router.post("/{room_id}/items", response_model=MemoryItemResponse, status_code=status.HTTP_201_CREATED)
+def create_item(room_id: uuid.UUID, body: MemoryItemCreate, db: Session = Depends(get_db)) -> MemoryItem:
+    """Create a memory item in a room."""
+    _get_room_or_404(db, room_id)
+    item = MemoryItem(
+        room_id=room_id,
+        content=body.content,
+        image_url=body.image_url,
+        position_x=body.position.x,
+        position_y=body.position.y,
+        position_z=body.position.z,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.get("/{room_id}/items/{item_id}", response_model=MemoryItemResponse)
+def get_item(room_id: uuid.UUID, item_id: uuid.UUID, db: Session = Depends(get_db)) -> MemoryItem:
+    """Get a memory item by ID."""
+    return _get_item_or_404(db, item_id, room_id)
+
+
+@router.patch("/{room_id}/items/{item_id}", response_model=MemoryItemResponse)
+def update_item(
+    room_id: uuid.UUID,
+    item_id: uuid.UUID,
+    body: MemoryItemUpdate,
+    db: Session = Depends(get_db),
+) -> MemoryItem:
+    """Update a memory item (content, position, image_url)."""
+    item = _get_item_or_404(db, item_id, room_id)
+    update_data = body.model_dump(exclude_unset=True)
+
+    # Handle nested position schema
+    if "position" in update_data and update_data["position"] is not None:
+        position = update_data.pop("position")
+        item.position_x = position["x"]
+        item.position_y = position["y"]
+        item.position_z = position["z"]
+    else:
+        update_data.pop("position", None)
+
+    for key, value in update_data.items():
+        setattr(item, key, value)
+
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{room_id}/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_item(room_id: uuid.UUID, item_id: uuid.UUID, db: Session = Depends(get_db)) -> None:
+    """Delete a memory item."""
+    item = _get_item_or_404(db, item_id, room_id)
+    db.delete(item)
+    db.commit()

--- a/backend/src/memory_palace/database.py
+++ b/backend/src/memory_palace/database.py
@@ -1,0 +1,55 @@
+"""Database connection and session management."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.orm import Session
+
+
+def get_database_url() -> str:
+    """Get database URL from environment variable."""
+    url = os.environ.get("DATABASE_URL", "")
+    if not url:
+        msg = "DATABASE_URL environment variable is not set"
+        raise ValueError(msg)
+    return url
+
+
+class Base(DeclarativeBase):
+    """SQLAlchemy declarative base class."""
+
+
+def create_session_factory(database_url: str | None = None) -> sessionmaker[Session]:
+    """Create a SQLAlchemy session factory.
+
+    Args:
+        database_url: Optional database URL. If not provided, reads from DATABASE_URL env var.
+
+    Returns:
+        A configured sessionmaker instance.
+    """
+    url = database_url or get_database_url()
+    engine = create_engine(url, echo=False)
+    return sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+
+def get_db() -> Generator[Session, None, None]:
+    """FastAPI dependency that yields a database session.
+
+    Yields:
+        A SQLAlchemy session that is automatically closed after use.
+    """
+    session_factory = create_session_factory()
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()

--- a/backend/src/memory_palace/main.py
+++ b/backend/src/memory_palace/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from memory_palace.api.health import router as health_router
+from memory_palace.api.reviews import router as reviews_router
 from memory_palace.api.rooms import router as rooms_router
 
 
@@ -32,6 +33,7 @@ def create_app() -> FastAPI:
 
     app.include_router(health_router)
     app.include_router(rooms_router)
+    app.include_router(reviews_router)
 
     return app
 

--- a/backend/src/memory_palace/main.py
+++ b/backend/src/memory_palace/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from memory_palace.api.health import router as health_router
+from memory_palace.api.rooms import router as rooms_router
 
 
 def create_app() -> FastAPI:
@@ -30,6 +31,7 @@ def create_app() -> FastAPI:
     )
 
     app.include_router(health_router)
+    app.include_router(rooms_router)
 
     return app
 

--- a/backend/src/memory_palace/models/__init__.py
+++ b/backend/src/memory_palace/models/__init__.py
@@ -1,0 +1,15 @@
+"""SQLAlchemy ORM models for Memory Palace."""
+
+from memory_palace.models.memory_item import MemoryItem
+from memory_palace.models.review_record import ReviewRecord
+from memory_palace.models.review_session import ReviewSession
+from memory_palace.models.room import Room
+from memory_palace.models.user import User
+
+__all__ = [
+    "MemoryItem",
+    "ReviewRecord",
+    "ReviewSession",
+    "Room",
+    "User",
+]

--- a/backend/src/memory_palace/models/memory_item.py
+++ b/backend/src/memory_palace/models/memory_item.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -29,11 +28,12 @@ class MemoryItem(Base):
     __tablename__ = "memory_items"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     room_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("rooms.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/memory_item.py
+++ b/backend/src/memory_palace/models/memory_item.py
@@ -1,0 +1,121 @@
+"""MemoryItem model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from memory_palace.database import Base
+
+if TYPE_CHECKING:
+    from memory_palace.models.review_record import ReviewRecord
+    from memory_palace.models.room import Room
+
+
+class MemoryItem(Base):
+    """A memory item placed in a room at a specific 3D position.
+
+    SM-2 parameters:
+        - ease_factor: Difficulty factor (minimum 1.3, default 2.5)
+        - interval: Review interval in days (default 1)
+        - repetitions: Number of consecutive correct answers (default 0)
+    """
+
+    __tablename__ = "memory_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    room_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("rooms.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    content: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        doc="Memory target text (1-10,000 characters)",
+    )
+    image_url: Mapped[str | None] = mapped_column(
+        String(2048),
+        nullable=True,
+        doc="Optional image URL for the memory item",
+    )
+
+    # 3D position in the room
+    position_x: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=0.0,
+        doc="X coordinate in 3D space (-1000.0 to 1000.0)",
+    )
+    position_y: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=0.0,
+        doc="Y coordinate in 3D space (-1000.0 to 1000.0)",
+    )
+    position_z: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=0.0,
+        doc="Z coordinate in 3D space (-1000.0 to 1000.0)",
+    )
+
+    # SM-2 algorithm parameters
+    ease_factor: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        default=2.5,
+        doc="SM-2 ease factor (minimum 1.3)",
+    )
+    interval: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=1,
+        doc="Review interval in days",
+    )
+    repetitions: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        doc="Number of consecutive correct answers",
+    )
+    last_reviewed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        doc="Timestamp of the last review",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    room: Mapped[Room] = relationship(
+        "Room",
+        back_populates="memory_items",
+    )
+    review_records: Mapped[list[ReviewRecord]] = relationship(
+        "ReviewRecord",
+        back_populates="memory_item",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<MemoryItem(id={self.id}, content={self.content[:30]!r}...)>"

--- a/backend/src/memory_palace/models/review_record.py
+++ b/backend/src/memory_palace/models/review_record.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, Integer, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -34,17 +33,18 @@ class ReviewRecord(Base):
     __tablename__ = "review_records"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     session_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("review_sessions.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
     memory_item_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("memory_items.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/review_record.py
+++ b/backend/src/memory_palace/models/review_record.py
@@ -1,0 +1,79 @@
+"""ReviewRecord model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from memory_palace.database import Base
+
+if TYPE_CHECKING:
+    from memory_palace.models.memory_item import MemoryItem
+    from memory_palace.models.review_session import ReviewSession
+
+
+class ReviewRecord(Base):
+    """A single review record for a memory item within a session.
+
+    Attributes:
+        quality: Self-assessment score (0-5).
+            0 = Complete blackout
+            1 = Incorrect, but recognized the correct answer
+            2 = Incorrect, but seemed easy to recall
+            3 = Correct with significant difficulty
+            4 = Correct after hesitation
+            5 = Perfect, instant recall
+        response_time_ms: Time taken to respond in milliseconds (max 300,000 = 5 min).
+    """
+
+    __tablename__ = "review_records"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("review_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    memory_item_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("memory_items.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    quality: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        doc="Self-assessment quality score (0-5)",
+    )
+    response_time_ms: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        doc="Response time in milliseconds (max 300,000)",
+    )
+    reviewed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    session: Mapped[ReviewSession] = relationship(
+        "ReviewSession",
+        back_populates="review_records",
+    )
+    memory_item: Mapped[MemoryItem] = relationship(
+        "MemoryItem",
+        back_populates="review_records",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ReviewRecord(id={self.id}, quality={self.quality})>"

--- a/backend/src/memory_palace/models/review_session.py
+++ b/backend/src/memory_palace/models/review_session.py
@@ -1,0 +1,72 @@
+"""ReviewSession model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, Integer, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from memory_palace.database import Base
+
+if TYPE_CHECKING:
+    from memory_palace.models.review_record import ReviewRecord
+    from memory_palace.models.room import Room
+
+
+class ReviewSession(Base):
+    """A review session grouping multiple review records.
+
+    Tracks a single study session where the user reviews items in a room.
+    """
+
+    __tablename__ = "review_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    room_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("rooms.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    total_items: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        doc="Total number of items reviewed in this session",
+    )
+    completed_items: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        doc="Number of items completed in this session",
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        doc="Timestamp when the session was completed (null if in progress)",
+    )
+
+    # Relationships
+    room: Mapped[Room] = relationship(
+        "Room",
+    )
+    review_records: Mapped[list[ReviewRecord]] = relationship(
+        "ReviewRecord",
+        back_populates="session",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<ReviewSession(id={self.id}, room_id={self.room_id})>"

--- a/backend/src/memory_palace/models/review_session.py
+++ b/backend/src/memory_palace/models/review_session.py
@@ -6,8 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, ForeignKey, Integer, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import DateTime, ForeignKey, Integer, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -26,11 +25,12 @@ class ReviewSession(Base):
     __tablename__ = "review_sessions"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     room_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("rooms.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/room.py
+++ b/backend/src/memory_palace/models/room.py
@@ -6,8 +6,8 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -23,11 +23,12 @@ class Room(Base):
     __tablename__ = "rooms"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )
     owner_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True),
+        Uuid,
         ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False,
         index=True,

--- a/backend/src/memory_palace/models/room.py
+++ b/backend/src/memory_palace/models/room.py
@@ -1,0 +1,73 @@
+"""Room model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import JSON, DateTime, ForeignKey, String, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from memory_palace.database import Base
+
+if TYPE_CHECKING:
+    from memory_palace.models.memory_item import MemoryItem
+    from memory_palace.models.user import User
+
+
+class Room(Base):
+    """A virtual room in the memory palace containing memory items."""
+
+    __tablename__ = "rooms"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    owner_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+    )
+    description: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+    )
+    layout_data: Mapped[dict | None] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=True,
+        default=dict,
+        doc="3D layout data for the room (floor, walls, decorations)",
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    owner: Mapped[User] = relationship(
+        "User",
+        back_populates="rooms",
+    )
+    memory_items: Mapped[list[MemoryItem]] = relationship(
+        "MemoryItem",
+        back_populates="room",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<Room(id={self.id}, name={self.name!r})>"

--- a/backend/src/memory_palace/models/user.py
+++ b/backend/src/memory_palace/models/user.py
@@ -1,0 +1,63 @@
+"""User model."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from memory_palace.database import Base
+
+if TYPE_CHECKING:
+    from memory_palace.models.room import Room
+
+
+class User(Base):
+    """User account for Memory Palace."""
+
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    username: Mapped[str] = mapped_column(
+        String(100),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    email: Mapped[str] = mapped_column(
+        String(255),
+        unique=True,
+        nullable=False,
+        index=True,
+    )
+    password_hash: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    # Relationships
+    rooms: Mapped[list[Room]] = relationship(
+        "Room",
+        back_populates="owner",
+        cascade="all, delete-orphan",
+    )
+
+    def __repr__(self) -> str:
+        return f"<User(id={self.id}, username={self.username!r})>"

--- a/backend/src/memory_palace/models/user.py
+++ b/backend/src/memory_palace/models/user.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import DateTime, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from memory_palace.database import Base
@@ -21,6 +21,7 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[uuid.UUID] = mapped_column(
+        Uuid,
         primary_key=True,
         default=uuid.uuid4,
     )

--- a/backend/src/memory_palace/schemas/__init__.py
+++ b/backend/src/memory_palace/schemas/__init__.py
@@ -1,0 +1,30 @@
+"""Pydantic schemas (request/response DTOs) for Memory Palace API."""
+
+from memory_palace.schemas.memory_item import (
+    MemoryItemCreate,
+    MemoryItemResponse,
+    MemoryItemUpdate,
+    PositionSchema,
+)
+from memory_palace.schemas.review import (
+    ReviewRecordCreate,
+    ReviewRecordResponse,
+    ReviewSessionResponse,
+)
+from memory_palace.schemas.room import RoomCreate, RoomResponse, RoomUpdate
+from memory_palace.schemas.user import UserCreate, UserResponse
+
+__all__ = [
+    "MemoryItemCreate",
+    "MemoryItemResponse",
+    "MemoryItemUpdate",
+    "PositionSchema",
+    "ReviewRecordCreate",
+    "ReviewRecordResponse",
+    "ReviewSessionResponse",
+    "RoomCreate",
+    "RoomResponse",
+    "RoomUpdate",
+    "UserCreate",
+    "UserResponse",
+]

--- a/backend/src/memory_palace/schemas/__init__.py
+++ b/backend/src/memory_palace/schemas/__init__.py
@@ -7,9 +7,11 @@ from memory_palace.schemas.memory_item import (
     PositionSchema,
 )
 from memory_palace.schemas.review import (
+    MemoryItemSM2Response,
     ReviewRecordCreate,
     ReviewRecordResponse,
     ReviewSessionResponse,
+    RoomStatsResponse,
 )
 from memory_palace.schemas.room import RoomCreate, RoomResponse, RoomUpdate
 from memory_palace.schemas.user import UserCreate, UserResponse
@@ -17,6 +19,7 @@ from memory_palace.schemas.user import UserCreate, UserResponse
 __all__ = [
     "MemoryItemCreate",
     "MemoryItemResponse",
+    "MemoryItemSM2Response",
     "MemoryItemUpdate",
     "PositionSchema",
     "ReviewRecordCreate",
@@ -24,6 +27,7 @@ __all__ = [
     "ReviewSessionResponse",
     "RoomCreate",
     "RoomResponse",
+    "RoomStatsResponse",
     "RoomUpdate",
     "UserCreate",
     "UserResponse",

--- a/backend/src/memory_palace/schemas/__init__.py
+++ b/backend/src/memory_palace/schemas/__init__.py
@@ -7,6 +7,11 @@ from memory_palace.schemas.memory_item import (
     PositionSchema,
 )
 from memory_palace.schemas.review import (
+    DailyStatsEntry,
+    DailyStatsResponse,
+    ForgettingCurveItem,
+    ForgettingCurvePoint,
+    ForgettingCurveResponse,
     MemoryItemSM2Response,
     ReviewRecordCreate,
     ReviewRecordResponse,
@@ -17,6 +22,11 @@ from memory_palace.schemas.room import RoomCreate, RoomResponse, RoomUpdate
 from memory_palace.schemas.user import UserCreate, UserResponse
 
 __all__ = [
+    "DailyStatsEntry",
+    "DailyStatsResponse",
+    "ForgettingCurveItem",
+    "ForgettingCurvePoint",
+    "ForgettingCurveResponse",
     "MemoryItemCreate",
     "MemoryItemResponse",
     "MemoryItemSM2Response",

--- a/backend/src/memory_palace/schemas/memory_item.py
+++ b/backend/src/memory_palace/schemas/memory_item.py
@@ -1,0 +1,91 @@
+"""MemoryItem schemas."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PositionSchema(BaseModel):
+    """3D position coordinates."""
+
+    x: float = Field(
+        ...,
+        ge=-1000.0,
+        le=1000.0,
+        description="X coordinate (-1000.0 to 1000.0)",
+    )
+    y: float = Field(
+        ...,
+        ge=-1000.0,
+        le=1000.0,
+        description="Y coordinate (-1000.0 to 1000.0)",
+    )
+    z: float = Field(
+        ...,
+        ge=-1000.0,
+        le=1000.0,
+        description="Z coordinate (-1000.0 to 1000.0)",
+    )
+
+
+class MemoryItemCreate(BaseModel):
+    """Schema for creating a memory item."""
+
+    content: str = Field(
+        ...,
+        min_length=1,
+        max_length=10000,
+        description="Memory target text (1-10,000 characters)",
+    )
+    image_url: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Optional image URL",
+    )
+    position: PositionSchema = Field(
+        default_factory=lambda: PositionSchema(x=0.0, y=0.0, z=0.0),
+        description="3D position in the room",
+    )
+
+
+class MemoryItemUpdate(BaseModel):
+    """Schema for updating a memory item."""
+
+    content: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=10000,
+        description="Memory target text (1-10,000 characters)",
+    )
+    image_url: str | None = Field(
+        default=None,
+        max_length=2048,
+        description="Optional image URL",
+    )
+    position: PositionSchema | None = Field(
+        default=None,
+        description="3D position in the room",
+    )
+
+
+class MemoryItemResponse(BaseModel):
+    """Schema for memory item response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    room_id: uuid.UUID
+    content: str
+    image_url: str | None
+    position_x: float
+    position_y: float
+    position_z: float
+    ease_factor: float
+    interval: int
+    repetitions: int
+    last_reviewed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/src/memory_palace/schemas/review.py
+++ b/backend/src/memory_palace/schemas/review.py
@@ -1,0 +1,56 @@
+"""Review schemas."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ReviewRecordCreate(BaseModel):
+    """Schema for recording a review result."""
+
+    memory_item_id: uuid.UUID = Field(
+        ...,
+        description="ID of the memory item being reviewed",
+    )
+    quality: int = Field(
+        ...,
+        ge=0,
+        le=5,
+        description="Self-assessment quality (0=blackout, 5=perfect recall)",
+    )
+    response_time_ms: int = Field(
+        ...,
+        gt=0,
+        le=300000,
+        description="Response time in milliseconds (max 300,000 = 5 minutes)",
+    )
+
+
+class ReviewRecordResponse(BaseModel):
+    """Schema for review record response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    session_id: uuid.UUID
+    memory_item_id: uuid.UUID
+    quality: int
+    response_time_ms: int
+    reviewed_at: datetime
+
+
+class ReviewSessionResponse(BaseModel):
+    """Schema for review session response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    room_id: uuid.UUID
+    total_items: int
+    completed_items: int
+    started_at: datetime
+    completed_at: datetime | None
+    review_records: list[ReviewRecordResponse] = Field(default_factory=list)

--- a/backend/src/memory_palace/schemas/review.py
+++ b/backend/src/memory_palace/schemas/review.py
@@ -80,3 +80,40 @@ class RoomStatsResponse(BaseModel):
     total_reviews: int = Field(..., description="Total review records")
     average_quality: float | None = Field(None, description="Average quality score")
     reviews_today: int = Field(..., description="Reviews completed today")
+
+
+class DailyStatsEntry(BaseModel):
+    """A single day's review statistics."""
+
+    date: str = Field(..., description="Date string (YYYY-MM-DD)")
+    review_count: int = Field(..., description="Number of reviews on this day")
+    average_quality: float | None = Field(None, description="Average quality score for the day")
+    correct_rate: float | None = Field(None, description="Percentage of reviews with quality >= 3")
+
+
+class DailyStatsResponse(BaseModel):
+    """Daily review statistics for chart rendering."""
+
+    entries: list[DailyStatsEntry] = Field(default_factory=list, description="Daily stats entries")
+
+
+class ForgettingCurvePoint(BaseModel):
+    """A point on the forgetting curve."""
+
+    days_since_review: float = Field(..., description="Days since last review")
+    retention: float = Field(..., description="Predicted retention probability (0-1)")
+
+
+class ForgettingCurveItem(BaseModel):
+    """Forgetting curve data for a single memory item."""
+
+    item_id: uuid.UUID = Field(..., description="Memory item ID")
+    content: str = Field(..., description="Memory item content (truncated)")
+    stability: float = Field(..., description="Stability (interval * ease_factor)")
+    curve: list[ForgettingCurvePoint] = Field(default_factory=list, description="Forgetting curve points")
+
+
+class ForgettingCurveResponse(BaseModel):
+    """Forgetting curve data for a room's items."""
+
+    items: list[ForgettingCurveItem] = Field(default_factory=list, description="Per-item forgetting curves")

--- a/backend/src/memory_palace/schemas/review.py
+++ b/backend/src/memory_palace/schemas/review.py
@@ -54,3 +54,29 @@ class ReviewSessionResponse(BaseModel):
     started_at: datetime
     completed_at: datetime | None
     review_records: list[ReviewRecordResponse] = Field(default_factory=list)
+
+
+class MemoryItemSM2Response(BaseModel):
+    """SM-2 parameters of a memory item after review update."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    ease_factor: float
+    interval: int
+    repetitions: int
+    last_reviewed_at: datetime | None
+
+
+class RoomStatsResponse(BaseModel):
+    """Schema for room review statistics."""
+
+    total_items: int = Field(..., description="Total memory items in the room")
+    reviewed_items: int = Field(..., description="Items reviewed at least once")
+    mastered_items: int = Field(..., description="Items with interval >= 21 days")
+    learning_items: int = Field(..., description="Items being learned (interval < 21)")
+    new_items: int = Field(..., description="Items never reviewed")
+    average_ease_factor: float | None = Field(None, description="Average ease factor")
+    total_reviews: int = Field(..., description="Total review records")
+    average_quality: float | None = Field(None, description="Average quality score")
+    reviews_today: int = Field(..., description="Reviews completed today")

--- a/backend/src/memory_palace/schemas/room.py
+++ b/backend/src/memory_palace/schemas/room.py
@@ -1,0 +1,61 @@
+"""Room schemas."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RoomCreate(BaseModel):
+    """Schema for creating a new room."""
+
+    name: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Room name (1-100 characters)",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Room description",
+    )
+    layout_data: dict[str, Any] | None = Field(
+        default=None,
+        description="3D layout data (JSON)",
+    )
+
+
+class RoomUpdate(BaseModel):
+    """Schema for updating a room."""
+
+    name: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=100,
+        description="Room name (1-100 characters)",
+    )
+    description: str | None = Field(
+        default=None,
+        description="Room description",
+    )
+    layout_data: dict[str, Any] | None = Field(
+        default=None,
+        description="3D layout data (JSON)",
+    )
+
+
+class RoomResponse(BaseModel):
+    """Schema for room response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    owner_id: uuid.UUID
+    name: str
+    description: str | None
+    layout_data: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/src/memory_palace/schemas/user.py
+++ b/backend/src/memory_palace/schemas/user.py
@@ -1,0 +1,43 @@
+"""User schemas."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class UserCreate(BaseModel):
+    """Schema for creating a new user."""
+
+    username: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+        description="Username (1-100 characters)",
+    )
+    email: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="Email address",
+    )
+    password: str = Field(
+        ...,
+        min_length=8,
+        max_length=128,
+        description="Password (8-128 characters)",
+    )
+
+
+class UserResponse(BaseModel):
+    """Schema for user response (excludes sensitive data)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    username: str
+    email: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/src/memory_palace/services/__init__.py
+++ b/backend/src/memory_palace/services/__init__.py
@@ -1,0 +1,9 @@
+"""Service layer for Memory Palace business logic."""
+
+from memory_palace.services.scheduling import SchedulingResult, SchedulingStrategy, SM2Strategy
+
+__all__ = [
+    "SM2Strategy",
+    "SchedulingResult",
+    "SchedulingStrategy",
+]

--- a/backend/src/memory_palace/services/review.py
+++ b/backend/src/memory_palace/services/review.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
@@ -228,3 +229,132 @@ def get_room_stats(db: Session, room_id: uuid.UUID) -> dict:
         "average_quality": round(float(avg_quality), 2) if avg_quality is not None else None,
         "reviews_today": reviews_today,
     }
+
+
+_MAX_DAILY_STATS_DAYS = 365
+_DEFAULT_DAILY_STATS_DAYS = 30
+_FORGETTING_CURVE_POINTS = 20
+_MAX_FORGETTING_CURVE_ITEMS = 20
+_CORRECT_QUALITY_THRESHOLD = 3
+_CONTENT_PREVIEW_LENGTH = 50
+_PERCENT_MULTIPLIER = 100
+_MIN_CURVE_DAYS = 7
+
+
+def get_daily_stats(db: Session, room_id: uuid.UUID, days: int = _DEFAULT_DAILY_STATS_DAYS) -> dict:
+    """Get daily review statistics for chart rendering.
+
+    Args:
+        db: Database session.
+        room_id: Room UUID.
+        days: Number of days to look back (max 365).
+
+    Returns:
+        Dictionary with 'entries' list of daily stats.
+    """
+    days = min(days, _MAX_DAILY_STATS_DAYS)
+    now = datetime.now(tz=UTC)
+    start_date = (now - timedelta(days=days)).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    # Get all review records for this room in the date range
+    session_ids_subquery = select(ReviewSession.id).where(ReviewSession.room_id == room_id)
+    records = list(
+        db.execute(
+            select(ReviewRecord).where(
+                ReviewRecord.session_id.in_(session_ids_subquery),
+                ReviewRecord.reviewed_at >= start_date,
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    # Group by date
+    daily_map: dict[str, list[int]] = {}
+    for record in records:
+        reviewed_at = _ensure_aware(record.reviewed_at)
+        date_str = reviewed_at.strftime("%Y-%m-%d")
+        if date_str not in daily_map:
+            daily_map[date_str] = []
+        daily_map[date_str].append(record.quality)
+
+    # Build entries for each day in the range
+    entries = []
+    current = start_date
+    while current <= now:
+        date_str = current.strftime("%Y-%m-%d")
+        qualities = daily_map.get(date_str, [])
+        review_count = len(qualities)
+        avg_q = round(sum(qualities) / len(qualities), 2) if qualities else None
+        correct_count = sum(1 for q in qualities if q >= _CORRECT_QUALITY_THRESHOLD)
+        correct_rate = round(correct_count / len(qualities) * _PERCENT_MULTIPLIER, 1) if qualities else None
+
+        entries.append(
+            {
+                "date": date_str,
+                "review_count": review_count,
+                "average_quality": avg_q,
+                "correct_rate": correct_rate,
+            }
+        )
+        current += timedelta(days=1)
+
+    return {"entries": entries}
+
+
+def get_forgetting_curves(db: Session, room_id: uuid.UUID) -> dict:
+    """Get forgetting curve data for items in a room.
+
+    Uses the formula R(t) = e^(-t/S) where S = interval * ease_factor (stability).
+
+    Args:
+        db: Database session.
+        room_id: Room UUID.
+
+    Returns:
+        Dictionary with 'items' list of forgetting curve data per item.
+    """
+    items = list(
+        db.execute(
+            select(MemoryItem)
+            .where(MemoryItem.room_id == room_id, MemoryItem.last_reviewed_at.isnot(None))
+            .order_by(MemoryItem.last_reviewed_at.desc())
+            .limit(_MAX_FORGETTING_CURVE_ITEMS)
+        )
+        .scalars()
+        .all()
+    )
+
+    result_items = []
+    for item in items:
+        stability = item.interval * item.ease_factor
+        # Prevent division by zero
+        if stability <= 0:
+            stability = 1.0
+
+        # Generate curve points from 0 to 2 * interval days
+        max_days = max(item.interval * 2, _MIN_CURVE_DAYS)
+        curve_points = []
+        for i in range(_FORGETTING_CURVE_POINTS + 1):
+            t = (i / _FORGETTING_CURVE_POINTS) * max_days
+            retention = math.exp(-t / stability)
+            curve_points.append(
+                {
+                    "days_since_review": round(t, 2),
+                    "retention": round(retention, 4),
+                }
+            )
+
+        content_preview = (
+            item.content[:_CONTENT_PREVIEW_LENGTH] if len(item.content) > _CONTENT_PREVIEW_LENGTH else item.content
+        )
+        result_items.append(
+            {
+                "item_id": item.id,
+                "content": content_preview,
+                "stability": round(stability, 2),
+                "curve": curve_points,
+            }
+        )
+
+    return {"items": result_items}

--- a/backend/src/memory_palace/services/review.py
+++ b/backend/src/memory_palace/services/review.py
@@ -1,0 +1,230 @@
+"""Review service: queue generation, review recording, and statistics."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import func, select
+
+from memory_palace.models.memory_item import MemoryItem
+from memory_palace.models.review_record import ReviewRecord
+from memory_palace.models.review_session import ReviewSession
+from memory_palace.services.scheduling import SchedulingStrategy, SM2Strategy
+
+if TYPE_CHECKING:
+    import uuid
+
+    from sqlalchemy.orm import Session
+
+# Items with interval >= this threshold are considered "mastered"
+_MASTERY_INTERVAL_DAYS = 21
+
+
+def _ensure_aware(dt: datetime) -> datetime:
+    """Ensure a datetime is timezone-aware (assume UTC if naive).
+
+    SQLite does not store timezone info, so datetimes from SQLite
+    may be naive. This helper normalizes them to UTC.
+    """
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt
+
+
+def _get_scheduling_strategy() -> SchedulingStrategy:
+    """Return the current scheduling strategy.
+
+    Currently SM-2; will be swapped to ML-based strategy in Phase 2.
+    """
+    return SM2Strategy()
+
+
+def get_review_queue(db: Session, room_id: uuid.UUID) -> list[MemoryItem]:
+    """Get memory items due for review in a room.
+
+    An item is due for review if:
+    - It has never been reviewed (last_reviewed_at is NULL), OR
+    - Its next review date (last_reviewed_at + interval days) is today or earlier.
+
+    Items are sorted by urgency: never-reviewed first, then by due date ascending.
+
+    Args:
+        db: Database session.
+        room_id: Room UUID to get queue for.
+
+    Returns:
+        List of MemoryItem objects due for review.
+    """
+    now = datetime.now(tz=UTC)
+
+    # Fetch all items in the room and filter in Python for SQLite compatibility
+    all_items = list(
+        db.execute(select(MemoryItem).where(MemoryItem.room_id == room_id).order_by(MemoryItem.created_at))
+        .scalars()
+        .all()
+    )
+
+    queue: list[MemoryItem] = []
+    for item in all_items:
+        if item.last_reviewed_at is None:
+            queue.append(item)
+        else:
+            reviewed_at = _ensure_aware(item.last_reviewed_at)
+            next_review_date = reviewed_at + timedelta(days=item.interval)
+            if next_review_date <= now:
+                queue.append(item)
+
+    # Sort: never-reviewed first, then by due date
+    def sort_key(item: MemoryItem) -> tuple[int, datetime]:
+        if item.last_reviewed_at is None:
+            return (0, _ensure_aware(item.created_at))
+        reviewed_at = _ensure_aware(item.last_reviewed_at)
+        return (1, reviewed_at + timedelta(days=item.interval))
+
+    queue.sort(key=sort_key)
+    return queue
+
+
+def record_review(
+    db: Session,
+    room_id: uuid.UUID,
+    memory_item_id: uuid.UUID,
+    quality: int,
+    response_time_ms: int,
+    session_id: uuid.UUID | None = None,
+) -> ReviewRecord:
+    """Record a review result and update SM-2 parameters on the memory item.
+
+    Args:
+        db: Database session.
+        room_id: Room UUID (used to verify item belongs to room).
+        memory_item_id: ID of the memory item being reviewed.
+        quality: Self-assessment score (0-5).
+        response_time_ms: Time to respond in milliseconds.
+        session_id: Optional review session ID. A new session is created if None.
+
+    Returns:
+        The created ReviewRecord.
+
+    Raises:
+        ValueError: If the memory item is not found in the specified room.
+    """
+    # Fetch the memory item
+    item = db.execute(
+        select(MemoryItem).where(
+            MemoryItem.id == memory_item_id,
+            MemoryItem.room_id == room_id,
+        )
+    ).scalar_one_or_none()
+
+    if item is None:
+        msg = f"MemoryItem {memory_item_id} not found in room {room_id}"
+        raise ValueError(msg)
+
+    # Create or fetch review session
+    if session_id is None:
+        session = ReviewSession(
+            room_id=room_id,
+            total_items=1,
+            completed_items=1,
+            completed_at=datetime.now(tz=UTC),
+        )
+        db.add(session)
+        db.flush()
+        session_id = session.id
+    else:
+        session = db.execute(select(ReviewSession).where(ReviewSession.id == session_id)).scalar_one_or_none()
+        if session is not None:
+            session.completed_items += 1
+            if session.completed_items >= session.total_items:
+                session.completed_at = datetime.now(tz=UTC)
+
+    # Calculate new SM-2 parameters
+    strategy = _get_scheduling_strategy()
+    result = strategy.calculate(
+        quality=quality,
+        ease_factor=item.ease_factor,
+        interval=item.interval,
+        repetitions=item.repetitions,
+    )
+
+    # Update memory item with new SM-2 parameters
+    item.ease_factor = result.ease_factor
+    item.interval = result.interval
+    item.repetitions = result.repetitions
+    item.last_reviewed_at = datetime.now(tz=UTC)
+
+    # Create review record
+    review_record = ReviewRecord(
+        session_id=session_id,
+        memory_item_id=memory_item_id,
+        quality=quality,
+        response_time_ms=response_time_ms,
+    )
+    db.add(review_record)
+    db.commit()
+    db.refresh(review_record)
+
+    return review_record
+
+
+def get_room_stats(db: Session, room_id: uuid.UUID) -> dict:
+    """Get review statistics for a room.
+
+    Returns:
+        Dictionary with:
+        - total_items: Total number of memory items in the room.
+        - reviewed_items: Number of items that have been reviewed at least once.
+        - mastered_items: Items with interval >= 21 days (well-learned).
+        - learning_items: Items with 0 < repetitions and interval < 21 days.
+        - new_items: Items never reviewed.
+        - average_ease_factor: Average ease factor across all items.
+        - total_reviews: Total number of review records.
+        - average_quality: Average quality score across all reviews.
+        - reviews_today: Number of reviews completed today.
+    """
+    # Total items in room
+    total_items = db.execute(select(func.count(MemoryItem.id)).where(MemoryItem.room_id == room_id)).scalar_one()
+
+    # Items categorized by learning state
+    items = list(db.execute(select(MemoryItem).where(MemoryItem.room_id == room_id)).scalars().all())
+
+    new_items = sum(1 for i in items if i.last_reviewed_at is None)
+    mastered_items = sum(1 for i in items if i.last_reviewed_at is not None and i.interval >= _MASTERY_INTERVAL_DAYS)
+    learning_items = sum(1 for i in items if i.last_reviewed_at is not None and i.interval < _MASTERY_INTERVAL_DAYS)
+
+    # Average ease factor
+    avg_ease = db.execute(select(func.avg(MemoryItem.ease_factor)).where(MemoryItem.room_id == room_id)).scalar_one()
+
+    # Review records via sessions
+    session_ids_subquery = select(ReviewSession.id).where(ReviewSession.room_id == room_id)
+
+    total_reviews = db.execute(
+        select(func.count(ReviewRecord.id)).where(ReviewRecord.session_id.in_(session_ids_subquery))
+    ).scalar_one()
+
+    avg_quality = db.execute(
+        select(func.avg(ReviewRecord.quality)).where(ReviewRecord.session_id.in_(session_ids_subquery))
+    ).scalar_one()
+
+    # Reviews today
+    today_start = datetime.now(tz=UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+    reviews_today = db.execute(
+        select(func.count(ReviewRecord.id)).where(
+            ReviewRecord.session_id.in_(session_ids_subquery),
+            ReviewRecord.reviewed_at >= today_start,
+        )
+    ).scalar_one()
+
+    return {
+        "total_items": total_items,
+        "reviewed_items": total_items - new_items,
+        "mastered_items": mastered_items,
+        "learning_items": learning_items,
+        "new_items": new_items,
+        "average_ease_factor": round(float(avg_ease), 2) if avg_ease is not None else None,
+        "total_reviews": total_reviews,
+        "average_quality": round(float(avg_quality), 2) if avg_quality is not None else None,
+        "reviews_today": reviews_today,
+    }

--- a/backend/src/memory_palace/services/scheduling.py
+++ b/backend/src/memory_palace/services/scheduling.py
@@ -1,0 +1,126 @@
+"""Spaced repetition scheduling strategies.
+
+Implements the Strategy pattern to allow future migration from SM-2 to ML-based models.
+
+SM-2 Algorithm Reference: https://super-memory.com/english/ol/sm2.htm
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+
+# SM-2 quality thresholds and constants
+_MAX_QUALITY = 5
+_PASS_THRESHOLD = 3
+_FIRST_SUCCESS_REPS = 1
+_SECOND_SUCCESS_REPS = 2
+_FIRST_SUCCESS_INTERVAL = 1
+_SECOND_SUCCESS_INTERVAL = 6
+
+
+@dataclass(frozen=True, slots=True)
+class SchedulingResult:
+    """Result of a scheduling calculation.
+
+    Attributes:
+        ease_factor: Updated ease factor (>= 1.3).
+        interval: Next review interval in days.
+        repetitions: Updated consecutive correct answer count.
+    """
+
+    ease_factor: float
+    interval: int
+    repetitions: int
+
+
+class SchedulingStrategy(abc.ABC):
+    """Abstract base class for spaced repetition scheduling strategies."""
+
+    @abc.abstractmethod
+    def calculate(
+        self,
+        quality: int,
+        ease_factor: float,
+        interval: int,
+        repetitions: int,
+    ) -> SchedulingResult:
+        """Calculate the next scheduling parameters after a review.
+
+        Args:
+            quality: Self-assessment score (0-5).
+            ease_factor: Current ease factor.
+            interval: Current review interval in days.
+            repetitions: Current count of consecutive correct answers.
+
+        Returns:
+            Updated scheduling parameters.
+        """
+
+
+class SM2Strategy(SchedulingStrategy):
+    """SM-2 (SuperMemo 2) spaced repetition scheduling strategy.
+
+    Rules:
+        - quality < 3: Reset repetitions to 0, interval to 1 (re-learn).
+        - quality >= 3: Increment repetitions, scale interval by ease_factor.
+        - ease_factor is updated based on quality and clamped to minimum 1.3.
+        - First successful review: interval = 1.
+        - Second successful review: interval = 6.
+        - Subsequent successful reviews: interval = round(interval * ease_factor).
+    """
+
+    MIN_EASE_FACTOR = 1.3
+
+    def calculate(
+        self,
+        quality: int,
+        ease_factor: float,
+        interval: int,
+        repetitions: int,
+    ) -> SchedulingResult:
+        """Calculate next SM-2 scheduling parameters.
+
+        Args:
+            quality: Self-assessment score (0-5).
+            ease_factor: Current ease factor (>= 1.3).
+            interval: Current review interval in days.
+            repetitions: Current consecutive correct answer count.
+
+        Returns:
+            Updated scheduling parameters.
+
+        Raises:
+            ValueError: If quality is not in range 0-5.
+        """
+        if not (0 <= quality <= _MAX_QUALITY):
+            msg = f"Quality must be between 0 and {_MAX_QUALITY}, got {quality}"
+            raise ValueError(msg)
+
+        # Update ease factor using the SM-2 formula
+        new_ease_factor = ease_factor + (0.1 - (_MAX_QUALITY - quality) * (0.08 + (_MAX_QUALITY - quality) * 0.02))
+        new_ease_factor = max(self.MIN_EASE_FACTOR, new_ease_factor)
+
+        if quality < _PASS_THRESHOLD:
+            # Failed recall: reset to re-learn
+            return SchedulingResult(
+                ease_factor=new_ease_factor,
+                interval=1,
+                repetitions=0,
+            )
+
+        # Successful recall: advance
+        new_repetitions = repetitions + 1
+
+        if new_repetitions == _FIRST_SUCCESS_REPS:
+            new_interval = _FIRST_SUCCESS_INTERVAL
+        elif new_repetitions == _SECOND_SUCCESS_REPS:
+            new_interval = _SECOND_SUCCESS_INTERVAL
+        else:
+            new_interval = round(interval * new_ease_factor)
+
+        return SchedulingResult(
+            ease_factor=new_ease_factor,
+            interval=new_interval,
+            repetitions=new_repetitions,
+        )

--- a/backend/tests/test_daily_stats_and_forgetting_curve.py
+++ b/backend/tests/test_daily_stats_and_forgetting_curve.py
@@ -1,0 +1,318 @@
+"""Tests for daily stats and forgetting curve API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from memory_palace.database import Base, get_db
+from memory_palace.main import app
+from memory_palace.models.user import User
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.orm import Session
+
+_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_TestSessionLocal = sessionmaker(bind=_engine)
+
+DUMMY_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-000000000002")
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    """Create all tables before each test and drop after."""
+    Base.metadata.create_all(_engine)
+
+    session = _TestSessionLocal()
+    existing = session.query(User).filter_by(id=DUMMY_OWNER_ID).first()
+    if not existing:
+        dummy_user = User(
+            id=DUMMY_OWNER_ID,
+            username="statuser",
+            email="stats@example.com",
+            password_hash="hash",
+        )
+        session.add(dummy_user)
+        session.commit()
+    session.close()
+
+    yield
+
+    Base.metadata.drop_all(_engine)
+
+
+def _override_get_db() -> Generator[Session, None, None]:
+    session = _TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create a test client with overridden database dependency."""
+    app.dependency_overrides[get_db] = _override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def room_id(client) -> str:
+    """Create a room and return its ID."""
+    resp = client.post("/api/rooms", json={"name": "Stats Test Room"})
+    return resp.json()["id"]
+
+
+@pytest.fixture
+def items_with_reviews(client, room_id) -> list[str]:
+    """Create items and record reviews, return item IDs."""
+    item_ids = []
+    for i in range(3):
+        resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": f"Test item {i}", "position": {"x": float(i), "y": 0, "z": 0}},
+        )
+        item_ids.append(resp.json()["id"])
+
+    # Record reviews for each item
+    for iid in item_ids:
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": iid, "quality": 4, "response_time_ms": 1000},
+        )
+
+    return item_ids
+
+
+# =============================================================================
+# Daily Stats tests
+# =============================================================================
+
+
+class TestDailyStats:
+    """Tests for GET /api/rooms/{room_id}/stats/daily."""
+
+    def test_daily_stats_empty_room(self, client, room_id):
+        """Empty room returns entries with zero counts."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=7")
+        assert response.status_code == 200
+        data = response.json()
+        assert "entries" in data
+        # Should have entries for each day in range
+        assert len(data["entries"]) >= 7
+        # All entries should have 0 reviews
+        for entry in data["entries"]:
+            assert entry["review_count"] == 0
+            assert entry["average_quality"] is None
+            assert entry["correct_rate"] is None
+
+    def test_daily_stats_with_reviews(self, client, room_id, items_with_reviews):
+        """Daily stats reflect recorded reviews."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=1")
+        assert response.status_code == 200
+        data = response.json()
+        # Find today's entry
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        today_entries = [e for e in data["entries"] if e["date"] == today]
+        assert len(today_entries) == 1
+        entry = today_entries[0]
+        assert entry["review_count"] == 3
+        assert entry["average_quality"] == 4.0
+        assert entry["correct_rate"] == 100.0
+
+    def test_daily_stats_default_days(self, client, room_id):
+        """Default is 30 days."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["entries"]) >= 30
+
+    def test_daily_stats_max_days_365(self, client, room_id):
+        """Days parameter max is 365."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=365")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["entries"]) >= 365
+
+    def test_daily_stats_invalid_days_rejected(self, client, room_id):
+        """Days > 365 is rejected."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=366")
+        assert response.status_code == 422
+
+    def test_daily_stats_zero_days_rejected(self, client, room_id):
+        """Days = 0 is rejected."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=0")
+        assert response.status_code == 422
+
+    def test_daily_stats_nonexistent_room_404(self, client):
+        """Daily stats for nonexistent room returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}/stats/daily")
+        assert response.status_code == 404
+
+    def test_daily_stats_correct_rate_calculation(self, client, room_id):
+        """Correct rate is calculated correctly: quality >= 3 is correct."""
+        # Create items with mixed quality scores
+        for i, q in enumerate([0, 1, 2, 3, 4, 5]):
+            resp = client.post(
+                f"/api/rooms/{room_id}/items",
+                json={"content": f"Q{q} item", "position": {"x": float(i + 10), "y": 0, "z": 0}},
+            )
+            iid = resp.json()["id"]
+            client.post(
+                f"/api/rooms/{room_id}/review",
+                json={"memory_item_id": iid, "quality": q, "response_time_ms": 1000},
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=1")
+        data = response.json()
+        today = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+        today_entry = next(e for e in data["entries"] if e["date"] == today)
+        # 3 out of 6 are correct (quality 3, 4, 5)
+        assert today_entry["correct_rate"] == 50.0
+
+    def test_daily_stats_entries_have_date_format(self, client, room_id):
+        """Entries have YYYY-MM-DD date format."""
+        response = client.get(f"/api/rooms/{room_id}/stats/daily?days=3")
+        data = response.json()
+        for entry in data["entries"]:
+            # Validate date format
+            datetime.strptime(entry["date"], "%Y-%m-%d")  # noqa: DTZ007
+
+
+# =============================================================================
+# Forgetting Curve tests
+# =============================================================================
+
+
+class TestForgettingCurve:
+    """Tests for GET /api/rooms/{room_id}/stats/forgetting-curve."""
+
+    def test_forgetting_curve_empty_room(self, client, room_id):
+        """Empty room returns empty items list."""
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["items"] == []
+
+    def test_forgetting_curve_unreviewed_items_excluded(self, client, room_id):
+        """Items that have never been reviewed are excluded."""
+        client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Unreviewed item", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        assert response.status_code == 200
+        assert response.json()["items"] == []
+
+    def test_forgetting_curve_with_reviewed_items(self, client, room_id, items_with_reviews):
+        """Reviewed items have forgetting curve data."""
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["items"]) == 3
+
+        for item in data["items"]:
+            assert "item_id" in item
+            assert "content" in item
+            assert "stability" in item
+            assert item["stability"] > 0
+            assert len(item["curve"]) == 21  # 20 points + 1 for t=0
+
+            # First point should have retention close to 1.0
+            assert item["curve"][0]["days_since_review"] == 0
+            assert item["curve"][0]["retention"] == 1.0
+
+            # Last point should have retention < 1.0
+            last_point = item["curve"][-1]
+            assert last_point["retention"] < 1.0
+            assert last_point["retention"] > 0
+
+    def test_forgetting_curve_retention_decreases(self, client, room_id, items_with_reviews):
+        """Retention should decrease over time (monotonically)."""
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        data = response.json()
+        for item in data["items"]:
+            curve = item["curve"]
+            for i in range(1, len(curve)):
+                assert curve[i]["retention"] <= curve[i - 1]["retention"]
+
+    def test_forgetting_curve_nonexistent_room_404(self, client):
+        """Forgetting curve for nonexistent room returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}/stats/forgetting-curve")
+        assert response.status_code == 404
+
+    def test_forgetting_curve_content_truncated(self, client, room_id):
+        """Content longer than 50 chars is truncated."""
+        long_content = "A" * 100
+        resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": long_content, "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        iid = resp.json()["id"]
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": iid, "quality": 5, "response_time_ms": 500},
+        )
+
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        data = response.json()
+        assert len(data["items"]) == 1
+        assert len(data["items"][0]["content"]) == 50
+
+    def test_forgetting_curve_stability_formula(self, client, room_id):
+        """Stability should equal interval * ease_factor."""
+        resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Stability test", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        iid = resp.json()["id"]
+        # Review with quality 5
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": iid, "quality": 5, "response_time_ms": 500},
+        )
+
+        # Get updated item to check parameters
+        item_resp = client.get(f"/api/rooms/{room_id}/items/{iid}")
+        item = item_resp.json()
+
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        data = response.json()
+        curve_item = data["items"][0]
+
+        expected_stability = round(item["interval"] * item["ease_factor"], 2)
+        assert curve_item["stability"] == expected_stability
+
+    def test_forgetting_curve_max_20_items(self, client, room_id):
+        """At most 20 items are returned."""
+        # Create and review 25 items
+        for i in range(25):
+            resp = client.post(
+                f"/api/rooms/{room_id}/items",
+                json={"content": f"Item {i}", "position": {"x": float(i % 10), "y": 0, "z": float(i // 10)}},
+            )
+            iid = resp.json()["id"]
+            client.post(
+                f"/api/rooms/{room_id}/review",
+                json={"memory_item_id": iid, "quality": 4, "response_time_ms": 500},
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/stats/forgetting-curve")
+        data = response.json()
+        assert len(data["items"]) <= 20

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -1,0 +1,695 @@
+"""Tests for SQLAlchemy ORM models (CRUD operations)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from memory_palace.database import Base
+from memory_palace.models import MemoryItem, ReviewRecord, ReviewSession, Room, User
+
+
+@pytest.fixture
+def db_session():
+    """Create an in-memory SQLite database session for testing."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine)
+    session = session_factory()
+    try:
+        yield session
+    finally:
+        session.close()
+        Base.metadata.drop_all(engine)
+
+
+# =============================================================================
+# User model tests
+# =============================================================================
+
+
+class TestUserModel:
+    """Tests for the User model."""
+
+    def test_create_user(self, db_session: Session):
+        """User can be created with required fields."""
+        user = User(
+            username="testuser",
+            email="test@example.com",
+            password_hash="hashed_password_123",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        assert user.id is not None
+        assert user.username == "testuser"
+        assert user.email == "test@example.com"
+        assert user.password_hash == "hashed_password_123"
+
+    def test_user_has_uuid_id(self, db_session: Session):
+        """User ID is a valid UUID."""
+        user = User(
+            username="uuiduser",
+            email="uuid@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        # ID should be a valid UUID (may be string in SQLite)
+        assert user.id is not None
+        if isinstance(user.id, uuid.UUID):
+            assert user.id.version == 4
+
+    def test_read_user(self, db_session: Session):
+        """User can be queried from database."""
+        user = User(
+            username="readuser",
+            email="read@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        found = db_session.query(User).filter_by(username="readuser").first()
+        assert found is not None
+        assert found.email == "read@example.com"
+
+    def test_update_user(self, db_session: Session):
+        """User fields can be updated."""
+        user = User(
+            username="updateuser",
+            email="update@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        user.email = "updated@example.com"
+        db_session.commit()
+        db_session.refresh(user)
+
+        assert user.email == "updated@example.com"
+
+    def test_delete_user(self, db_session: Session):
+        """User can be deleted from database."""
+        user = User(
+            username="deleteuser",
+            email="delete@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+
+        db_session.delete(user)
+        db_session.commit()
+
+        found = db_session.query(User).filter_by(username="deleteuser").first()
+        assert found is None
+
+    def test_user_repr(self, db_session: Session):
+        """User repr includes id and username."""
+        user = User(
+            username="repruser",
+            email="repr@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        repr_str = repr(user)
+        assert "User" in repr_str
+        assert "repruser" in repr_str
+
+
+# =============================================================================
+# Room model tests
+# =============================================================================
+
+
+class TestRoomModel:
+    """Tests for the Room model."""
+
+    @pytest.fixture
+    def user(self, db_session: Session):
+        """Create a user for room tests."""
+        user = User(
+            username="roomowner",
+            email="owner@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+        return user
+
+    def test_create_room(self, db_session: Session, user: User):
+        """Room can be created with required fields."""
+        room = Room(
+            owner_id=user.id,
+            name="Test Room",
+            description="A test room",
+        )
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        assert room.id is not None
+        assert room.name == "Test Room"
+        assert room.description == "A test room"
+        assert room.owner_id == user.id
+
+    def test_room_with_layout_data(self, db_session: Session, user: User):
+        """Room can store JSONB layout data."""
+        layout = {
+            "floor": {"width": 10, "height": 10},
+            "walls": [{"x": 0, "y": 0, "z": 0, "width": 10, "height": 3}],
+        }
+        room = Room(
+            owner_id=user.id,
+            name="Layout Room",
+            layout_data=layout,
+        )
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        assert room.layout_data is not None
+        assert room.layout_data["floor"]["width"] == 10
+
+    def test_room_owner_relationship(self, db_session: Session, user: User):
+        """Room has a relationship to its owner."""
+        room = Room(
+            owner_id=user.id,
+            name="Relationship Room",
+        )
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        assert room.owner is not None
+        assert room.owner.username == "roomowner"
+
+    def test_user_rooms_relationship(self, db_session: Session, user: User):
+        """User has a list of owned rooms."""
+        room1 = Room(owner_id=user.id, name="Room 1")
+        room2 = Room(owner_id=user.id, name="Room 2")
+        db_session.add_all([room1, room2])
+        db_session.commit()
+        db_session.refresh(user)
+
+        assert len(user.rooms) == 2
+
+    def test_update_room(self, db_session: Session, user: User):
+        """Room fields can be updated."""
+        room = Room(owner_id=user.id, name="Original")
+        db_session.add(room)
+        db_session.commit()
+
+        room.name = "Updated"
+        db_session.commit()
+        db_session.refresh(room)
+
+        assert room.name == "Updated"
+
+    def test_delete_room(self, db_session: Session, user: User):
+        """Room can be deleted."""
+        room = Room(owner_id=user.id, name="To Delete")
+        db_session.add(room)
+        db_session.commit()
+
+        db_session.delete(room)
+        db_session.commit()
+
+        found = db_session.query(Room).filter_by(name="To Delete").first()
+        assert found is None
+
+    def test_room_repr(self, db_session: Session, user: User):
+        """Room repr includes id and name."""
+        room = Room(owner_id=user.id, name="ReprRoom")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        repr_str = repr(room)
+        assert "Room" in repr_str
+        assert "ReprRoom" in repr_str
+
+
+# =============================================================================
+# MemoryItem model tests
+# =============================================================================
+
+
+class TestMemoryItemModel:
+    """Tests for the MemoryItem model."""
+
+    @pytest.fixture
+    def room(self, db_session: Session):
+        """Create a user and room for memory item tests."""
+        user = User(
+            username="itemowner",
+            email="item@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="Item Room")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+        return room
+
+    def test_create_memory_item(self, db_session: Session, room: Room):
+        """MemoryItem can be created with required fields."""
+        item = MemoryItem(
+            room_id=room.id,
+            content="The capital of France is Paris",
+            position_x=1.0,
+            position_y=2.0,
+            position_z=3.0,
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.id is not None
+        assert item.content == "The capital of France is Paris"
+        assert item.position_x == 1.0
+        assert item.position_y == 2.0
+        assert item.position_z == 3.0
+
+    def test_memory_item_sm2_defaults(self, db_session: Session, room: Room):
+        """MemoryItem has correct SM-2 default values."""
+        item = MemoryItem(
+            room_id=room.id,
+            content="SM-2 defaults test",
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.ease_factor == 2.5
+        assert item.interval == 1
+        assert item.repetitions == 0
+        assert item.last_reviewed_at is None
+
+    def test_memory_item_position_defaults(self, db_session: Session, room: Room):
+        """MemoryItem position defaults to origin."""
+        item = MemoryItem(
+            room_id=room.id,
+            content="Position defaults test",
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.position_x == 0.0
+        assert item.position_y == 0.0
+        assert item.position_z == 0.0
+
+    def test_memory_item_with_image_url(self, db_session: Session, room: Room):
+        """MemoryItem can store an optional image URL."""
+        item = MemoryItem(
+            room_id=room.id,
+            content="Item with image",
+            image_url="https://example.com/image.png",
+        )
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.image_url == "https://example.com/image.png"
+
+    def test_memory_item_room_relationship(self, db_session: Session, room: Room):
+        """MemoryItem has a relationship to its room."""
+        item = MemoryItem(room_id=room.id, content="Relationship test")
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.room is not None
+        assert item.room.name == "Item Room"
+
+    def test_room_memory_items_relationship(self, db_session: Session, room: Room):
+        """Room has a list of memory items."""
+        item1 = MemoryItem(room_id=room.id, content="Item 1")
+        item2 = MemoryItem(room_id=room.id, content="Item 2")
+        db_session.add_all([item1, item2])
+        db_session.commit()
+        db_session.refresh(room)
+
+        assert len(room.memory_items) == 2
+
+    def test_update_memory_item_sm2_params(self, db_session: Session, room: Room):
+        """SM-2 parameters can be updated after review."""
+        item = MemoryItem(room_id=room.id, content="Update test")
+        db_session.add(item)
+        db_session.commit()
+
+        # Simulate a quality=5 review
+        item.ease_factor = 2.6
+        item.interval = 6
+        item.repetitions = 1
+        item.last_reviewed_at = datetime.now(tz=UTC)
+        db_session.commit()
+        db_session.refresh(item)
+
+        assert item.ease_factor == 2.6
+        assert item.interval == 6
+        assert item.repetitions == 1
+        assert item.last_reviewed_at is not None
+
+    def test_delete_memory_item(self, db_session: Session, room: Room):
+        """MemoryItem can be deleted."""
+        item = MemoryItem(room_id=room.id, content="To delete")
+        db_session.add(item)
+        db_session.commit()
+
+        db_session.delete(item)
+        db_session.commit()
+
+        found = db_session.query(MemoryItem).filter_by(content="To delete").first()
+        assert found is None
+
+
+# =============================================================================
+# ReviewSession model tests
+# =============================================================================
+
+
+class TestReviewSessionModel:
+    """Tests for the ReviewSession model."""
+
+    @pytest.fixture
+    def room(self, db_session: Session):
+        """Create a user and room for review session tests."""
+        user = User(
+            username="reviewowner",
+            email="review@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="Review Room")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+        return room
+
+    def test_create_review_session(self, db_session: Session, room: Room):
+        """ReviewSession can be created."""
+        session = ReviewSession(
+            room_id=room.id,
+            total_items=5,
+            completed_items=0,
+        )
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        assert session.id is not None
+        assert session.total_items == 5
+        assert session.completed_items == 0
+        assert session.completed_at is None
+
+    def test_complete_review_session(self, db_session: Session, room: Room):
+        """ReviewSession can be marked as completed."""
+        session = ReviewSession(
+            room_id=room.id,
+            total_items=3,
+            completed_items=0,
+        )
+        db_session.add(session)
+        db_session.commit()
+
+        session.completed_items = 3
+        session.completed_at = datetime.now(tz=UTC)
+        db_session.commit()
+        db_session.refresh(session)
+
+        assert session.completed_items == 3
+        assert session.completed_at is not None
+
+    def test_review_session_room_relationship(self, db_session: Session, room: Room):
+        """ReviewSession has a relationship to its room."""
+        session = ReviewSession(room_id=room.id, total_items=1)
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        assert session.room is not None
+        assert session.room.name == "Review Room"
+
+    def test_delete_review_session(self, db_session: Session, room: Room):
+        """ReviewSession can be deleted."""
+        session = ReviewSession(room_id=room.id, total_items=1)
+        db_session.add(session)
+        db_session.commit()
+
+        db_session.delete(session)
+        db_session.commit()
+
+        found = db_session.query(ReviewSession).filter_by(room_id=room.id).first()
+        assert found is None
+
+
+# =============================================================================
+# ReviewRecord model tests
+# =============================================================================
+
+
+class TestReviewRecordModel:
+    """Tests for the ReviewRecord model."""
+
+    @pytest.fixture
+    def review_context(self, db_session: Session):
+        """Create user, room, item, and session for review record tests."""
+        user = User(
+            username="recordowner",
+            email="record@example.com",
+            password_hash="hash",
+        )
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="Record Room")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        item = MemoryItem(room_id=room.id, content="Review target")
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        session = ReviewSession(room_id=room.id, total_items=1)
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        return {"room": room, "item": item, "session": session}
+
+    def test_create_review_record(self, db_session: Session, review_context):
+        """ReviewRecord can be created with quality and response time."""
+        record = ReviewRecord(
+            session_id=review_context["session"].id,
+            memory_item_id=review_context["item"].id,
+            quality=5,
+            response_time_ms=1500,
+        )
+        db_session.add(record)
+        db_session.commit()
+        db_session.refresh(record)
+
+        assert record.id is not None
+        assert record.quality == 5
+        assert record.response_time_ms == 1500
+
+    def test_review_record_quality_range(self, db_session: Session, review_context):
+        """ReviewRecord supports quality values 0-5."""
+        for q in range(6):
+            record = ReviewRecord(
+                session_id=review_context["session"].id,
+                memory_item_id=review_context["item"].id,
+                quality=q,
+                response_time_ms=1000,
+            )
+            db_session.add(record)
+        db_session.commit()
+
+        records = db_session.query(ReviewRecord).all()
+        qualities = sorted([r.quality for r in records])
+        assert qualities == [0, 1, 2, 3, 4, 5]
+
+    def test_review_record_session_relationship(self, db_session: Session, review_context):
+        """ReviewRecord has a relationship to its session."""
+        record = ReviewRecord(
+            session_id=review_context["session"].id,
+            memory_item_id=review_context["item"].id,
+            quality=4,
+            response_time_ms=2000,
+        )
+        db_session.add(record)
+        db_session.commit()
+        db_session.refresh(record)
+
+        assert record.session is not None
+        assert record.session.total_items == 1
+
+    def test_review_record_memory_item_relationship(self, db_session: Session, review_context):
+        """ReviewRecord has a relationship to its memory item."""
+        record = ReviewRecord(
+            session_id=review_context["session"].id,
+            memory_item_id=review_context["item"].id,
+            quality=3,
+            response_time_ms=3000,
+        )
+        db_session.add(record)
+        db_session.commit()
+        db_session.refresh(record)
+
+        assert record.memory_item is not None
+        assert record.memory_item.content == "Review target"
+
+    def test_session_review_records_relationship(self, db_session: Session, review_context):
+        """ReviewSession has a list of review records."""
+        for i in range(3):
+            record = ReviewRecord(
+                session_id=review_context["session"].id,
+                memory_item_id=review_context["item"].id,
+                quality=i + 3,
+                response_time_ms=1000 * (i + 1),
+            )
+            db_session.add(record)
+        db_session.commit()
+        db_session.refresh(review_context["session"])
+
+        assert len(review_context["session"].review_records) == 3
+
+    def test_delete_review_record(self, db_session: Session, review_context):
+        """ReviewRecord can be deleted."""
+        record = ReviewRecord(
+            session_id=review_context["session"].id,
+            memory_item_id=review_context["item"].id,
+            quality=5,
+            response_time_ms=500,
+        )
+        db_session.add(record)
+        db_session.commit()
+
+        db_session.delete(record)
+        db_session.commit()
+
+        found = db_session.query(ReviewRecord).first()
+        assert found is None
+
+    def test_review_record_repr(self, db_session: Session, review_context):
+        """ReviewRecord repr includes id and quality."""
+        record = ReviewRecord(
+            session_id=review_context["session"].id,
+            memory_item_id=review_context["item"].id,
+            quality=4,
+            response_time_ms=1200,
+        )
+        db_session.add(record)
+        db_session.commit()
+        db_session.refresh(record)
+
+        repr_str = repr(record)
+        assert "ReviewRecord" in repr_str
+        assert "4" in repr_str
+
+
+# =============================================================================
+# Cascade delete tests
+# =============================================================================
+
+
+class TestCascadeDelete:
+    """Tests for cascade delete behavior."""
+
+    def test_delete_user_cascades_to_rooms(self, db_session: Session):
+        """Deleting a user also deletes their rooms."""
+        user = User(username="cascade_user", email="cascade@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="Cascade Room")
+        db_session.add(room)
+        db_session.commit()
+
+        db_session.delete(user)
+        db_session.commit()
+
+        assert db_session.query(Room).count() == 0
+
+    def test_delete_room_cascades_to_items(self, db_session: Session):
+        """Deleting a room also deletes its memory items."""
+        user = User(username="cascade_room", email="cascade_room@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="To Delete Room")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        item = MemoryItem(room_id=room.id, content="Cascade item")
+        db_session.add(item)
+        db_session.commit()
+
+        db_session.delete(room)
+        db_session.commit()
+
+        assert db_session.query(MemoryItem).count() == 0
+
+    def test_delete_session_cascades_to_records(self, db_session: Session):
+        """Deleting a review session also deletes its records."""
+        user = User(username="cascade_session", email="cascade_session@example.com", password_hash="hash")
+        db_session.add(user)
+        db_session.commit()
+        db_session.refresh(user)
+
+        room = Room(owner_id=user.id, name="Cascade Session Room")
+        db_session.add(room)
+        db_session.commit()
+        db_session.refresh(room)
+
+        item = MemoryItem(room_id=room.id, content="Cascade review item")
+        db_session.add(item)
+        db_session.commit()
+        db_session.refresh(item)
+
+        session = ReviewSession(room_id=room.id, total_items=1)
+        db_session.add(session)
+        db_session.commit()
+        db_session.refresh(session)
+
+        record = ReviewRecord(
+            session_id=session.id,
+            memory_item_id=item.id,
+            quality=5,
+            response_time_ms=1000,
+        )
+        db_session.add(record)
+        db_session.commit()
+
+        db_session.delete(session)
+        db_session.commit()
+
+        assert db_session.query(ReviewRecord).count() == 0

--- a/backend/tests/test_reviews_api.py
+++ b/backend/tests/test_reviews_api.py
@@ -1,0 +1,419 @@
+"""Tests for Review API endpoints (review-queue, review, stats)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from memory_palace.database import Base, get_db
+from memory_palace.main import app
+from memory_palace.models.memory_item import MemoryItem
+from memory_palace.models.user import User
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.orm import Session
+
+# Shared engine for all tests — StaticPool ensures the same in-memory DB is reused.
+_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_TestSessionLocal = sessionmaker(bind=_engine)
+
+DUMMY_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    """Create all tables before each test and drop after."""
+    Base.metadata.create_all(_engine)
+
+    session = _TestSessionLocal()
+    existing = session.query(User).filter_by(id=DUMMY_OWNER_ID).first()
+    if not existing:
+        dummy_user = User(
+            id=DUMMY_OWNER_ID,
+            username="testuser",
+            email="test@example.com",
+            password_hash="hash",
+        )
+        session.add(dummy_user)
+        session.commit()
+    session.close()
+
+    yield
+
+    Base.metadata.drop_all(_engine)
+
+
+def _override_get_db() -> Generator[Session, None, None]:
+    session = _TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create a test client with overridden database dependency."""
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def room_id(client) -> str:
+    """Create a room and return its ID."""
+    resp = client.post("/api/rooms", json={"name": "Review Test Room"})
+    return resp.json()["id"]
+
+
+@pytest.fixture
+def item_id(client, room_id) -> str:
+    """Create a memory item and return its ID."""
+    resp = client.post(
+        f"/api/rooms/{room_id}/items",
+        json={
+            "content": "The capital of Japan is Tokyo",
+            "position": {"x": 1.0, "y": 0.0, "z": 2.0},
+        },
+    )
+    return resp.json()["id"]
+
+
+# =============================================================================
+# Review Queue tests
+# =============================================================================
+
+
+class TestReviewQueue:
+    """Tests for GET /api/rooms/{room_id}/review-queue."""
+
+    def test_empty_room_returns_empty_queue(self, client, room_id):
+        """Empty room has no items to review."""
+        response = client.get(f"/api/rooms/{room_id}/review-queue")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_new_items_appear_in_queue(self, client, room_id, item_id):
+        """Items that have never been reviewed appear in the queue."""
+        response = client.get(f"/api/rooms/{room_id}/review-queue")
+        assert response.status_code == 200
+        items = response.json()
+        assert len(items) == 1
+        assert items[0]["id"] == item_id
+
+    def test_multiple_new_items_in_queue(self, client, room_id):
+        """All new items appear in the queue."""
+        for i in range(3):
+            client.post(
+                f"/api/rooms/{room_id}/items",
+                json={
+                    "content": f"Item {i}",
+                    "position": {"x": float(i), "y": 0, "z": 0},
+                },
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/review-queue")
+        assert response.status_code == 200
+        assert len(response.json()) == 3
+
+    def test_reviewed_item_not_in_queue_immediately(self, client, room_id, item_id):
+        """An item just reviewed with q=5 should not be in the queue immediately."""
+        # Review the item
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={
+                "memory_item_id": item_id,
+                "quality": 5,
+                "response_time_ms": 1000,
+            },
+        )
+
+        response = client.get(f"/api/rooms/{room_id}/review-queue")
+        assert response.status_code == 200
+        assert len(response.json()) == 0
+
+    def test_queue_nonexistent_room_404(self, client):
+        """Queue for a nonexistent room returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}/review-queue")
+        assert response.status_code == 404
+
+    def test_overdue_items_appear_in_queue(self, client, room_id):
+        """Items past their review interval appear in the queue."""
+        # Create an item and manually set it as overdue in the DB
+        resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "Overdue item",
+                "position": {"x": 0, "y": 0, "z": 0},
+            },
+        )
+        item_id = resp.json()["id"]
+
+        # Directly update the DB to make it overdue
+        session = _TestSessionLocal()
+        item = session.query(MemoryItem).filter_by(id=uuid.UUID(item_id)).first()
+        item.last_reviewed_at = datetime.now(tz=UTC) - timedelta(days=10)
+        item.interval = 1
+        item.repetitions = 1
+        session.commit()
+        session.close()
+
+        response = client.get(f"/api/rooms/{room_id}/review-queue")
+        assert response.status_code == 200
+        items = response.json()
+        assert len(items) == 1
+        assert items[0]["id"] == item_id
+
+
+# =============================================================================
+# Review Recording tests
+# =============================================================================
+
+
+class TestReviewRecording:
+    """Tests for POST /api/rooms/{room_id}/review."""
+
+    def test_record_review_success(self, client, room_id, item_id):
+        """Successfully record a review and get a review record back."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={
+                "memory_item_id": item_id,
+                "quality": 5,
+                "response_time_ms": 1200,
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["quality"] == 5
+        assert data["response_time_ms"] == 1200
+        assert data["memory_item_id"] == item_id
+        assert "id" in data
+        assert "session_id" in data
+        assert "reviewed_at" in data
+
+    def test_review_updates_sm2_parameters(self, client, room_id, item_id):
+        """After review, SM-2 parameters on the item are updated."""
+        # Review with quality=5
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={
+                "memory_item_id": item_id,
+                "quality": 5,
+                "response_time_ms": 800,
+            },
+        )
+
+        # Check the item's updated parameters
+        item_resp = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        item_data = item_resp.json()
+        assert item_data["repetitions"] == 1
+        assert item_data["interval"] == 1
+        assert item_data["ease_factor"] > 2.5  # Increased for q=5
+        assert item_data["last_reviewed_at"] is not None
+
+    def test_review_quality_0_resets(self, client, room_id, item_id):
+        """Quality=0 resets repetitions and interval."""
+        # First review with q=5
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 5, "response_time_ms": 500},
+        )
+        # Second review with q=0
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 0, "response_time_ms": 5000},
+        )
+
+        item_resp = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        item_data = item_resp.json()
+        assert item_data["repetitions"] == 0
+        assert item_data["interval"] == 1
+
+    def test_review_all_quality_levels(self, client, room_id):
+        """Each quality level (0-5) is accepted."""
+        for q in range(6):
+            resp = client.post(
+                f"/api/rooms/{room_id}/items",
+                json={"content": f"Q{q} item", "position": {"x": float(q), "y": 0, "z": 0}},
+            )
+            iid = resp.json()["id"]
+            review_resp = client.post(
+                f"/api/rooms/{room_id}/review",
+                json={"memory_item_id": iid, "quality": q, "response_time_ms": 1000},
+            )
+            assert review_resp.status_code == 201
+            assert review_resp.json()["quality"] == q
+
+    def test_review_nonexistent_room_404(self, client, item_id):
+        """Review with nonexistent room returns 404."""
+        fake_room = str(uuid.uuid4())
+        response = client.post(
+            f"/api/rooms/{fake_room}/review",
+            json={"memory_item_id": item_id, "quality": 3, "response_time_ms": 1000},
+        )
+        assert response.status_code == 404
+
+    def test_review_nonexistent_item_404(self, client, room_id):
+        """Review with nonexistent item returns 404."""
+        fake_item = str(uuid.uuid4())
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": fake_item, "quality": 3, "response_time_ms": 1000},
+        )
+        assert response.status_code == 404
+
+    def test_review_invalid_quality_rejected(self, client, room_id, item_id):
+        """Quality outside 0-5 is rejected with 422."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 6, "response_time_ms": 1000},
+        )
+        assert response.status_code == 422
+
+    def test_review_negative_quality_rejected(self, client, room_id, item_id):
+        """Negative quality is rejected with 422."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": -1, "response_time_ms": 1000},
+        )
+        assert response.status_code == 422
+
+    def test_review_response_time_zero_rejected(self, client, room_id, item_id):
+        """response_time_ms of 0 is rejected (must be > 0)."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 3, "response_time_ms": 0},
+        )
+        assert response.status_code == 422
+
+    def test_review_response_time_exceeds_max_rejected(self, client, room_id, item_id):
+        """response_time_ms exceeding 300000 is rejected."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 3, "response_time_ms": 300001},
+        )
+        assert response.status_code == 422
+
+    def test_review_response_time_max_accepted(self, client, room_id, item_id):
+        """response_time_ms of exactly 300000 is accepted."""
+        response = client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 3, "response_time_ms": 300000},
+        )
+        assert response.status_code == 201
+
+
+# =============================================================================
+# Stats tests
+# =============================================================================
+
+
+class TestRoomStats:
+    """Tests for GET /api/rooms/{room_id}/stats."""
+
+    def test_stats_empty_room(self, client, room_id):
+        """Stats for an empty room."""
+        response = client.get(f"/api/rooms/{room_id}/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_items"] == 0
+        assert data["reviewed_items"] == 0
+        assert data["mastered_items"] == 0
+        assert data["learning_items"] == 0
+        assert data["new_items"] == 0
+        assert data["total_reviews"] == 0
+        assert data["reviews_today"] == 0
+
+    def test_stats_with_new_items(self, client, room_id, item_id):
+        """Stats show new items correctly."""
+        response = client.get(f"/api/rooms/{room_id}/stats")
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["new_items"] == 1
+        assert data["reviewed_items"] == 0
+
+    def test_stats_after_review(self, client, room_id, item_id):
+        """Stats update after a review."""
+        client.post(
+            f"/api/rooms/{room_id}/review",
+            json={"memory_item_id": item_id, "quality": 4, "response_time_ms": 1500},
+        )
+
+        response = client.get(f"/api/rooms/{room_id}/stats")
+        data = response.json()
+        assert data["total_items"] == 1
+        assert data["reviewed_items"] == 1
+        assert data["new_items"] == 0
+        assert data["learning_items"] == 1  # interval < 21
+        assert data["total_reviews"] == 1
+        assert data["reviews_today"] == 1
+        assert data["average_quality"] == 4.0
+
+    def test_stats_multiple_reviews(self, client, room_id):
+        """Stats accumulate across multiple reviews."""
+        # Create 3 items and review each
+        item_ids = []
+        for i in range(3):
+            resp = client.post(
+                f"/api/rooms/{room_id}/items",
+                json={"content": f"Stats item {i}", "position": {"x": float(i), "y": 0, "z": 0}},
+            )
+            item_ids.append(resp.json()["id"])
+
+        for iid in item_ids:
+            client.post(
+                f"/api/rooms/{room_id}/review",
+                json={"memory_item_id": iid, "quality": 5, "response_time_ms": 500},
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/stats")
+        data = response.json()
+        assert data["total_items"] == 3
+        assert data["reviewed_items"] == 3
+        assert data["total_reviews"] == 3
+        assert data["average_quality"] == 5.0
+
+    def test_stats_nonexistent_room_404(self, client):
+        """Stats for nonexistent room returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}/stats")
+        assert response.status_code == 404
+
+    def test_stats_mastered_items(self, client, room_id):
+        """Items with interval >= 21 are counted as mastered."""
+        resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Mastered item", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        iid = resp.json()["id"]
+
+        # Manually set interval >= 21 and mark as reviewed
+        session = _TestSessionLocal()
+        item = session.query(MemoryItem).filter_by(id=uuid.UUID(iid)).first()
+        item.interval = 30
+        item.repetitions = 5
+        item.last_reviewed_at = datetime.now(tz=UTC)
+        session.commit()
+        session.close()
+
+        response = client.get(f"/api/rooms/{room_id}/stats")
+        data = response.json()
+        assert data["mastered_items"] == 1
+        assert data["learning_items"] == 0

--- a/backend/tests/test_rooms_api.py
+++ b/backend/tests/test_rooms_api.py
@@ -1,0 +1,420 @@
+"""Tests for Room and MemoryItem CRUD API endpoints."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import StaticPool, create_engine
+from sqlalchemy.orm import sessionmaker
+
+from memory_palace.database import Base, get_db
+from memory_palace.main import app
+from memory_palace.models.user import User
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+    from sqlalchemy.orm import Session
+
+# Shared engine for all tests — StaticPool ensures the same in-memory DB is reused.
+_engine = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+_TestSessionLocal = sessionmaker(bind=_engine)
+
+
+@pytest.fixture(autouse=True)
+def _setup_db():
+    """Create all tables before each test and drop after."""
+    Base.metadata.create_all(_engine)
+
+    # Create dummy user required by Room.owner_id FK
+    session = _TestSessionLocal()
+    existing = session.query(User).filter_by(id=uuid.UUID("00000000-0000-0000-0000-000000000001")).first()
+    if not existing:
+        dummy_user = User(
+            id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+            username="testuser",
+            email="test@example.com",
+            password_hash="hash",
+        )
+        session.add(dummy_user)
+        session.commit()
+    session.close()
+
+    yield
+
+    Base.metadata.drop_all(_engine)
+
+
+def _override_get_db() -> Generator[Session, None, None]:
+    session = _TestSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client() -> Generator[TestClient, None, None]:
+    """Create a test client with overridden database dependency."""
+    app.dependency_overrides[get_db] = _override_get_db
+
+    with TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+# =============================================================================
+# Room CRUD tests
+# =============================================================================
+
+
+class TestRoomAPI:
+    """Tests for Room CRUD endpoints."""
+
+    def test_list_rooms_empty(self, client: TestClient):
+        """GET /api/rooms returns empty list when no rooms exist."""
+        response = client.get("/api/rooms")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_room(self, client: TestClient):
+        """POST /api/rooms creates a new room."""
+        response = client.post(
+            "/api/rooms",
+            json={"name": "Test Room", "description": "A test room"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == "Test Room"
+        assert data["description"] == "A test room"
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_create_room_minimal(self, client: TestClient):
+        """POST /api/rooms works with only required fields."""
+        response = client.post("/api/rooms", json={"name": "Minimal"})
+        assert response.status_code == 201
+        assert response.json()["name"] == "Minimal"
+
+    def test_create_room_empty_name_rejected(self, client: TestClient):
+        """POST /api/rooms rejects empty name."""
+        response = client.post("/api/rooms", json={"name": ""})
+        assert response.status_code == 422
+
+    def test_create_room_name_too_long_rejected(self, client: TestClient):
+        """POST /api/rooms rejects name longer than 100 chars."""
+        response = client.post("/api/rooms", json={"name": "a" * 101})
+        assert response.status_code == 422
+
+    def test_get_room(self, client: TestClient):
+        """GET /api/rooms/{room_id} returns the room."""
+        create_resp = client.post("/api/rooms", json={"name": "Get Room"})
+        room_id = create_resp.json()["id"]
+
+        response = client.get(f"/api/rooms/{room_id}")
+        assert response.status_code == 200
+        assert response.json()["name"] == "Get Room"
+
+    def test_get_room_not_found(self, client: TestClient):
+        """GET /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{fake_id}")
+        assert response.status_code == 404
+
+    def test_update_room(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} updates the room."""
+        create_resp = client.post("/api/rooms", json={"name": "Original"})
+        room_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}",
+            json={"name": "Updated"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Updated"
+
+    def test_update_room_partial(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} supports partial updates."""
+        create_resp = client.post(
+            "/api/rooms",
+            json={"name": "Partial", "description": "Original desc"},
+        )
+        room_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}",
+            json={"description": "New desc"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Partial"
+        assert data["description"] == "New desc"
+
+    def test_update_room_not_found(self, client: TestClient):
+        """PATCH /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.patch(f"/api/rooms/{fake_id}", json={"name": "X"})
+        assert response.status_code == 404
+
+    def test_delete_room(self, client: TestClient):
+        """DELETE /api/rooms/{room_id} removes the room."""
+        create_resp = client.post("/api/rooms", json={"name": "To Delete"})
+        room_id = create_resp.json()["id"]
+
+        response = client.delete(f"/api/rooms/{room_id}")
+        assert response.status_code == 204
+
+        # Confirm deletion
+        get_resp = client.get(f"/api/rooms/{room_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_room_not_found(self, client: TestClient):
+        """DELETE /api/rooms/{room_id} returns 404 for nonexistent room."""
+        fake_id = str(uuid.uuid4())
+        response = client.delete(f"/api/rooms/{fake_id}")
+        assert response.status_code == 404
+
+    def test_list_rooms_returns_created_rooms(self, client: TestClient):
+        """GET /api/rooms lists all created rooms."""
+        client.post("/api/rooms", json={"name": "Room 1"})
+        client.post("/api/rooms", json={"name": "Room 2"})
+
+        response = client.get("/api/rooms")
+        assert response.status_code == 200
+        rooms = response.json()
+        assert len(rooms) == 2
+
+    def test_create_room_with_layout_data(self, client: TestClient):
+        """POST /api/rooms stores layout_data."""
+        layout = {"floor": {"width": 20, "depth": 20}, "walls": []}
+        response = client.post(
+            "/api/rooms",
+            json={"name": "Layout Room", "layout_data": layout},
+        )
+        assert response.status_code == 201
+        assert response.json()["layout_data"]["floor"]["width"] == 20
+
+
+# =============================================================================
+# MemoryItem CRUD tests
+# =============================================================================
+
+
+class TestMemoryItemAPI:
+    """Tests for MemoryItem CRUD endpoints nested under rooms."""
+
+    @pytest.fixture
+    def room_id(self, client: TestClient) -> str:
+        """Create a room and return its ID."""
+        resp = client.post("/api/rooms", json={"name": "Item Test Room"})
+        return resp.json()["id"]
+
+    def test_list_items_empty(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items returns empty list."""
+        response = client.get(f"/api/rooms/{room_id}/items")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_create_item(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items creates a memory item."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "The capital of France is Paris",
+                "position": {"x": 1.0, "y": 0.0, "z": 2.5},
+            },
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["content"] == "The capital of France is Paris"
+        assert data["position_x"] == 1.0
+        assert data["position_z"] == 2.5
+        assert data["room_id"] == room_id
+        # Check SM-2 defaults
+        assert data["ease_factor"] == 2.5
+        assert data["interval"] == 1
+        assert data["repetitions"] == 0
+
+    def test_create_item_default_position(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items uses default position (0,0,0)."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Default position item"},
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["position_x"] == 0.0
+        assert data["position_y"] == 0.0
+        assert data["position_z"] == 0.0
+
+    def test_create_item_empty_content_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects empty content."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_content_too_long_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects content over 10000 chars."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "a" * 10001, "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_position_out_of_bounds_rejected(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items rejects out-of-bounds positions."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "OOB", "position": {"x": 2000.0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 422
+
+    def test_create_item_nonexistent_room(self, client: TestClient):
+        """POST /api/rooms/{room_id}/items returns 404 for fake room."""
+        fake_id = str(uuid.uuid4())
+        response = client.post(
+            f"/api/rooms/{fake_id}/items",
+            json={"content": "Test", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        assert response.status_code == 404
+
+    def test_get_item(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items/{item_id} returns the item."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Get me", "position": {"x": 1, "y": 0, "z": 1}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        assert response.status_code == 200
+        assert response.json()["content"] == "Get me"
+
+    def test_get_item_not_found(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.get(f"/api/rooms/{room_id}/items/{fake_id}")
+        assert response.status_code == 404
+
+    def test_update_item_content(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} updates content."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Original", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{item_id}",
+            json={"content": "Updated"},
+        )
+        assert response.status_code == 200
+        assert response.json()["content"] == "Updated"
+
+    def test_update_item_position(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} updates position."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Move me", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{item_id}",
+            json={"position": {"x": 5.0, "y": 0.0, "z": 3.0}},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["position_x"] == 5.0
+        assert data["position_z"] == 3.0
+
+    def test_update_item_not_found(self, client: TestClient, room_id: str):
+        """PATCH /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.patch(
+            f"/api/rooms/{room_id}/items/{fake_id}",
+            json={"content": "X"},
+        )
+        assert response.status_code == 404
+
+    def test_delete_item(self, client: TestClient, room_id: str):
+        """DELETE /api/rooms/{room_id}/items/{item_id} removes the item."""
+        create_resp = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Delete me", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+        item_id = create_resp.json()["id"]
+
+        response = client.delete(f"/api/rooms/{room_id}/items/{item_id}")
+        assert response.status_code == 204
+
+        # Confirm deletion
+        get_resp = client.get(f"/api/rooms/{room_id}/items/{item_id}")
+        assert get_resp.status_code == 404
+
+    def test_delete_item_not_found(self, client: TestClient, room_id: str):
+        """DELETE /api/rooms/{room_id}/items/{item_id} returns 404."""
+        fake_id = str(uuid.uuid4())
+        response = client.delete(f"/api/rooms/{room_id}/items/{fake_id}")
+        assert response.status_code == 404
+
+    def test_list_items_returns_all_items(self, client: TestClient, room_id: str):
+        """GET /api/rooms/{room_id}/items returns all items."""
+        for i in range(3):
+            client.post(
+                f"/api/rooms/{room_id}/items",
+                json={
+                    "content": f"Item {i}",
+                    "position": {"x": float(i), "y": 0, "z": 0},
+                },
+            )
+
+        response = client.get(f"/api/rooms/{room_id}/items")
+        assert response.status_code == 200
+        assert len(response.json()) == 3
+
+    def test_delete_room_cascades_to_items(self, client: TestClient, room_id: str):
+        """Deleting a room also deletes its items."""
+        client.post(
+            f"/api/rooms/{room_id}/items",
+            json={"content": "Cascade test", "position": {"x": 0, "y": 0, "z": 0}},
+        )
+
+        client.delete(f"/api/rooms/{room_id}")
+
+        # Room and items should be gone
+        assert client.get(f"/api/rooms/{room_id}").status_code == 404
+
+    def test_create_item_with_image_url(self, client: TestClient, room_id: str):
+        """POST /api/rooms/{room_id}/items supports image_url."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "Item with image",
+                "image_url": "https://example.com/img.png",
+                "position": {"x": 0, "y": 0, "z": 0},
+            },
+        )
+        assert response.status_code == 201
+        assert response.json()["image_url"] == "https://example.com/img.png"
+
+    def test_item_content_up_to_500_accepted(self, client: TestClient, room_id: str):
+        """Items with content up to 500 chars are accepted."""
+        response = client.post(
+            f"/api/rooms/{room_id}/items",
+            json={
+                "content": "a" * 500,
+                "position": {"x": 0, "y": 0, "z": 0},
+            },
+        )
+        assert response.status_code == 201

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,0 +1,430 @@
+"""Tests for Pydantic schemas (request/response DTOs)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from memory_palace.schemas import (
+    MemoryItemCreate,
+    MemoryItemResponse,
+    MemoryItemUpdate,
+    PositionSchema,
+    ReviewRecordCreate,
+    ReviewRecordResponse,
+    ReviewSessionResponse,
+    RoomCreate,
+    RoomResponse,
+    RoomUpdate,
+    UserCreate,
+    UserResponse,
+)
+
+# =============================================================================
+# UserCreate validation tests
+# =============================================================================
+
+
+class TestUserCreate:
+    """Tests for UserCreate schema validation."""
+
+    def test_valid_user_create(self):
+        """Valid user creation data passes validation."""
+        user = UserCreate(username="testuser", email="test@example.com", password="securepass")
+        assert user.username == "testuser"
+        assert user.email == "test@example.com"
+
+    def test_username_too_long(self):
+        """Username exceeding 100 characters is rejected."""
+        with pytest.raises(ValidationError):
+            UserCreate(username="a" * 101, email="test@example.com", password="securepass")
+
+    def test_username_empty(self):
+        """Empty username is rejected."""
+        with pytest.raises(ValidationError):
+            UserCreate(username="", email="test@example.com", password="securepass")
+
+    def test_password_too_short(self):
+        """Password shorter than 8 characters is rejected."""
+        with pytest.raises(ValidationError):
+            UserCreate(username="testuser", email="test@example.com", password="short")
+
+    def test_password_too_long(self):
+        """Password exceeding 128 characters is rejected."""
+        with pytest.raises(ValidationError):
+            UserCreate(username="testuser", email="test@example.com", password="a" * 129)
+
+
+class TestUserResponse:
+    """Tests for UserResponse schema."""
+
+    def test_user_response_from_dict(self):
+        """UserResponse can be created from a dict."""
+        now = datetime.now(tz=UTC)
+        user_id = uuid.uuid4()
+        response = UserResponse(
+            id=user_id,
+            username="testuser",
+            email="test@example.com",
+            created_at=now,
+            updated_at=now,
+        )
+        assert response.id == user_id
+        assert response.username == "testuser"
+
+
+# =============================================================================
+# RoomCreate validation tests
+# =============================================================================
+
+
+class TestRoomCreate:
+    """Tests for RoomCreate schema validation."""
+
+    def test_valid_room_create(self):
+        """Valid room creation data passes validation."""
+        room = RoomCreate(name="My Room", description="A test room")
+        assert room.name == "My Room"
+        assert room.description == "A test room"
+
+    def test_room_name_empty(self):
+        """Empty room name is rejected."""
+        with pytest.raises(ValidationError):
+            RoomCreate(name="")
+
+    def test_room_name_too_long(self):
+        """Room name exceeding 100 characters is rejected."""
+        with pytest.raises(ValidationError):
+            RoomCreate(name="a" * 101)
+
+    def test_room_with_layout_data(self):
+        """Room can include layout data."""
+        layout = {"floor": {"width": 10, "height": 10}}
+        room = RoomCreate(name="Layout Room", layout_data=layout)
+        assert room.layout_data is not None
+        assert room.layout_data["floor"]["width"] == 10
+
+    def test_room_optional_fields(self):
+        """Room can be created with only required fields."""
+        room = RoomCreate(name="Minimal Room")
+        assert room.description is None
+        assert room.layout_data is None
+
+
+class TestRoomUpdate:
+    """Tests for RoomUpdate schema validation."""
+
+    def test_partial_update(self):
+        """RoomUpdate allows partial updates."""
+        update = RoomUpdate(name="Updated Name")
+        assert update.name == "Updated Name"
+        assert update.description is None
+
+    def test_update_name_too_long(self):
+        """Updated room name exceeding 100 characters is rejected."""
+        with pytest.raises(ValidationError):
+            RoomUpdate(name="a" * 101)
+
+
+class TestRoomResponse:
+    """Tests for RoomResponse schema."""
+
+    def test_room_response_from_dict(self):
+        """RoomResponse can be created from a dict."""
+        now = datetime.now(tz=UTC)
+        response = RoomResponse(
+            id=uuid.uuid4(),
+            owner_id=uuid.uuid4(),
+            name="Test Room",
+            description=None,
+            layout_data=None,
+            created_at=now,
+            updated_at=now,
+        )
+        assert response.name == "Test Room"
+
+
+# =============================================================================
+# PositionSchema validation tests
+# =============================================================================
+
+
+class TestPositionSchema:
+    """Tests for PositionSchema validation."""
+
+    def test_valid_position(self):
+        """Valid position passes validation."""
+        pos = PositionSchema(x=1.0, y=2.0, z=3.0)
+        assert pos.x == 1.0
+        assert pos.y == 2.0
+        assert pos.z == 3.0
+
+    def test_position_at_bounds(self):
+        """Position at boundary values passes validation."""
+        pos = PositionSchema(x=-1000.0, y=1000.0, z=0.0)
+        assert pos.x == -1000.0
+        assert pos.y == 1000.0
+
+    def test_position_x_too_large(self):
+        """X coordinate exceeding 1000.0 is rejected."""
+        with pytest.raises(ValidationError):
+            PositionSchema(x=1000.1, y=0.0, z=0.0)
+
+    def test_position_x_too_small(self):
+        """X coordinate below -1000.0 is rejected."""
+        with pytest.raises(ValidationError):
+            PositionSchema(x=-1000.1, y=0.0, z=0.0)
+
+    def test_position_y_too_large(self):
+        """Y coordinate exceeding 1000.0 is rejected."""
+        with pytest.raises(ValidationError):
+            PositionSchema(x=0.0, y=1001.0, z=0.0)
+
+    def test_position_z_too_small(self):
+        """Z coordinate below -1000.0 is rejected."""
+        with pytest.raises(ValidationError):
+            PositionSchema(x=0.0, y=0.0, z=-1001.0)
+
+
+# =============================================================================
+# MemoryItemCreate validation tests
+# =============================================================================
+
+
+class TestMemoryItemCreate:
+    """Tests for MemoryItemCreate schema validation."""
+
+    def test_valid_memory_item_create(self):
+        """Valid memory item creation data passes validation."""
+        item = MemoryItemCreate(
+            content="The capital of France is Paris",
+            position=PositionSchema(x=1.0, y=2.0, z=3.0),
+        )
+        assert item.content == "The capital of France is Paris"
+        assert item.position.x == 1.0
+
+    def test_content_empty(self):
+        """Empty content is rejected."""
+        with pytest.raises(ValidationError):
+            MemoryItemCreate(content="")
+
+    def test_content_too_long(self):
+        """Content exceeding 10,000 characters is rejected."""
+        with pytest.raises(ValidationError):
+            MemoryItemCreate(content="a" * 10001)
+
+    def test_default_position(self):
+        """Default position is origin (0, 0, 0)."""
+        item = MemoryItemCreate(content="Default position")
+        assert item.position.x == 0.0
+        assert item.position.y == 0.0
+        assert item.position.z == 0.0
+
+    def test_with_image_url(self):
+        """Memory item can include an image URL."""
+        item = MemoryItemCreate(
+            content="Item with image",
+            image_url="https://example.com/image.png",
+        )
+        assert item.image_url == "https://example.com/image.png"
+
+    def test_image_url_too_long(self):
+        """Image URL exceeding 2048 characters is rejected."""
+        with pytest.raises(ValidationError):
+            MemoryItemCreate(content="Test", image_url="https://example.com/" + "a" * 2048)
+
+    def test_position_out_of_bounds_rejected(self):
+        """Memory item with out-of-bounds position is rejected."""
+        with pytest.raises(ValidationError):
+            MemoryItemCreate(
+                content="Out of bounds",
+                position=PositionSchema(x=2000.0, y=0.0, z=0.0),
+            )
+
+
+class TestMemoryItemUpdate:
+    """Tests for MemoryItemUpdate schema validation."""
+
+    def test_partial_update(self):
+        """MemoryItemUpdate allows partial updates."""
+        update = MemoryItemUpdate(content="Updated content")
+        assert update.content == "Updated content"
+        assert update.position is None
+
+    def test_update_position(self):
+        """MemoryItemUpdate can update position."""
+        update = MemoryItemUpdate(position=PositionSchema(x=5.0, y=6.0, z=7.0))
+        assert update.position is not None
+        assert update.position.x == 5.0
+
+
+class TestMemoryItemResponse:
+    """Tests for MemoryItemResponse schema."""
+
+    def test_memory_item_response(self):
+        """MemoryItemResponse includes SM-2 parameters."""
+        now = datetime.now(tz=UTC)
+        response = MemoryItemResponse(
+            id=uuid.uuid4(),
+            room_id=uuid.uuid4(),
+            content="Test item",
+            image_url=None,
+            position_x=1.0,
+            position_y=2.0,
+            position_z=3.0,
+            ease_factor=2.5,
+            interval=1,
+            repetitions=0,
+            last_reviewed_at=None,
+            created_at=now,
+            updated_at=now,
+        )
+        assert response.ease_factor == 2.5
+        assert response.interval == 1
+        assert response.repetitions == 0
+
+
+# =============================================================================
+# ReviewRecordCreate validation tests
+# =============================================================================
+
+
+class TestReviewRecordCreate:
+    """Tests for ReviewRecordCreate schema validation."""
+
+    def test_valid_review_record(self):
+        """Valid review record passes validation."""
+        record = ReviewRecordCreate(
+            memory_item_id=uuid.uuid4(),
+            quality=5,
+            response_time_ms=1500,
+        )
+        assert record.quality == 5
+        assert record.response_time_ms == 1500
+
+    def test_quality_below_minimum(self):
+        """Quality below 0 is rejected."""
+        with pytest.raises(ValidationError):
+            ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=-1,
+                response_time_ms=1000,
+            )
+
+    def test_quality_above_maximum(self):
+        """Quality above 5 is rejected."""
+        with pytest.raises(ValidationError):
+            ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=6,
+                response_time_ms=1000,
+            )
+
+    def test_all_quality_values_valid(self):
+        """Quality values 0-5 are all valid."""
+        for q in range(6):
+            record = ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=q,
+                response_time_ms=1000,
+            )
+            assert record.quality == q
+
+    def test_response_time_zero(self):
+        """Response time of 0 is rejected (must be positive)."""
+        with pytest.raises(ValidationError):
+            ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=3,
+                response_time_ms=0,
+            )
+
+    def test_response_time_negative(self):
+        """Negative response time is rejected."""
+        with pytest.raises(ValidationError):
+            ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=3,
+                response_time_ms=-100,
+            )
+
+    def test_response_time_exceeds_maximum(self):
+        """Response time exceeding 300,000ms (5 min) is rejected."""
+        with pytest.raises(ValidationError):
+            ReviewRecordCreate(
+                memory_item_id=uuid.uuid4(),
+                quality=3,
+                response_time_ms=300001,
+            )
+
+    def test_response_time_at_maximum(self):
+        """Response time at exactly 300,000ms is valid."""
+        record = ReviewRecordCreate(
+            memory_item_id=uuid.uuid4(),
+            quality=3,
+            response_time_ms=300000,
+        )
+        assert record.response_time_ms == 300000
+
+
+class TestReviewRecordResponse:
+    """Tests for ReviewRecordResponse schema."""
+
+    def test_review_record_response(self):
+        """ReviewRecordResponse can be created from a dict."""
+        now = datetime.now(tz=UTC)
+        response = ReviewRecordResponse(
+            id=uuid.uuid4(),
+            session_id=uuid.uuid4(),
+            memory_item_id=uuid.uuid4(),
+            quality=4,
+            response_time_ms=2000,
+            reviewed_at=now,
+        )
+        assert response.quality == 4
+
+
+class TestReviewSessionResponse:
+    """Tests for ReviewSessionResponse schema."""
+
+    def test_review_session_response(self):
+        """ReviewSessionResponse includes review records."""
+        now = datetime.now(tz=UTC)
+        response = ReviewSessionResponse(
+            id=uuid.uuid4(),
+            room_id=uuid.uuid4(),
+            total_items=5,
+            completed_items=3,
+            started_at=now,
+            completed_at=None,
+            review_records=[],
+        )
+        assert response.total_items == 5
+        assert response.completed_at is None
+        assert response.review_records == []
+
+    def test_review_session_with_records(self):
+        """ReviewSessionResponse can include nested review records."""
+        now = datetime.now(tz=UTC)
+        record = ReviewRecordResponse(
+            id=uuid.uuid4(),
+            session_id=uuid.uuid4(),
+            memory_item_id=uuid.uuid4(),
+            quality=5,
+            response_time_ms=800,
+            reviewed_at=now,
+        )
+        response = ReviewSessionResponse(
+            id=uuid.uuid4(),
+            room_id=uuid.uuid4(),
+            total_items=1,
+            completed_items=1,
+            started_at=now,
+            completed_at=now,
+            review_records=[record],
+        )
+        assert len(response.review_records) == 1
+        assert response.review_records[0].quality == 5

--- a/backend/tests/test_sm2.py
+++ b/backend/tests/test_sm2.py
@@ -1,0 +1,235 @@
+"""Tests for SM-2 scheduling algorithm.
+
+Covers all quality levels (0-5) and edge cases per Issue #10 requirements.
+Target: >= 90% test coverage for SM-2 calculation logic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memory_palace.services.scheduling import SchedulingResult, SM2Strategy
+
+# Default SM-2 parameters for a new item
+DEFAULT_EASE = 2.5
+DEFAULT_INTERVAL = 1
+DEFAULT_REPS = 0
+
+
+@pytest.fixture
+def strategy() -> SM2Strategy:
+    """Create an SM2Strategy instance."""
+    return SM2Strategy()
+
+
+class TestSM2Quality5:
+    """quality=5: Perfect, instant recall."""
+
+    def test_first_review_perfect(self, strategy):
+        """First perfect review: interval=1, repetitions=1, ease increases."""
+        result = strategy.calculate(quality=5, ease_factor=DEFAULT_EASE, interval=DEFAULT_INTERVAL, repetitions=0)
+        assert result.repetitions == 1
+        assert result.interval == 1
+        assert result.ease_factor > DEFAULT_EASE  # EF increases for q=5
+
+    def test_second_review_perfect(self, strategy):
+        """Second perfect review: interval=6, repetitions=2."""
+        result = strategy.calculate(quality=5, ease_factor=2.6, interval=1, repetitions=1)
+        assert result.repetitions == 2
+        assert result.interval == 6
+
+    def test_third_review_perfect(self, strategy):
+        """Third+ review: interval scales by ease_factor."""
+        result = strategy.calculate(quality=5, ease_factor=2.6, interval=6, repetitions=2)
+        assert result.repetitions == 3
+        # interval = round(6 * 2.7) = round(16.2) = 16 (ease increases to ~2.7)
+        assert result.interval > 6
+
+
+class TestSM2Quality4:
+    """quality=4: Correct after hesitation."""
+
+    def test_first_review_q4(self, strategy):
+        """q=4 first review: successful, interval=1."""
+        result = strategy.calculate(quality=4, ease_factor=DEFAULT_EASE, interval=DEFAULT_INTERVAL, repetitions=0)
+        assert result.repetitions == 1
+        assert result.interval == 1
+        # EF stays approximately the same for q=4
+        assert result.ease_factor >= SM2Strategy.MIN_EASE_FACTOR
+
+    def test_subsequent_review_q4(self, strategy):
+        """q=4 subsequent: interval scales, ease_factor stays similar."""
+        result = strategy.calculate(quality=4, ease_factor=2.5, interval=6, repetitions=2)
+        assert result.repetitions == 3
+        assert result.interval >= 6
+
+
+class TestSM2Quality3:
+    """quality=3: Correct with significant difficulty."""
+
+    def test_first_review_q3(self, strategy):
+        """q=3 first review: passes but ease_factor decreases."""
+        result = strategy.calculate(quality=3, ease_factor=DEFAULT_EASE, interval=DEFAULT_INTERVAL, repetitions=0)
+        assert result.repetitions == 1
+        assert result.interval == 1
+        assert result.ease_factor < DEFAULT_EASE  # EF decreases for q=3
+
+    def test_ease_factor_clamped_at_minimum(self, strategy):
+        """Ease factor never goes below 1.3 even with repeated q=3."""
+        ef = DEFAULT_EASE
+        interval = 1
+        reps = 0
+        # Simulate many q=3 reviews
+        for _ in range(20):
+            result = strategy.calculate(quality=3, ease_factor=ef, interval=interval, repetitions=reps)
+            ef = result.ease_factor
+            interval = result.interval
+            reps = result.repetitions
+        assert ef >= SM2Strategy.MIN_EASE_FACTOR
+
+
+class TestSM2Quality2:
+    """quality=2: Incorrect, but seemed easy to recall."""
+
+    def test_q2_resets_to_relearn(self, strategy):
+        """q=2 resets repetitions to 0 and interval to 1."""
+        result = strategy.calculate(quality=2, ease_factor=2.5, interval=15, repetitions=5)
+        assert result.repetitions == 0
+        assert result.interval == 1
+
+    def test_q2_ease_factor_decreases(self, strategy):
+        """q=2 decreases ease factor but clamps at minimum."""
+        result = strategy.calculate(quality=2, ease_factor=2.5, interval=1, repetitions=0)
+        assert result.ease_factor < 2.5
+        assert result.ease_factor >= SM2Strategy.MIN_EASE_FACTOR
+
+
+class TestSM2Quality1:
+    """quality=1: Incorrect, but recognized the correct answer."""
+
+    def test_q1_resets(self, strategy):
+        """q=1 resets repetitions and interval."""
+        result = strategy.calculate(quality=1, ease_factor=2.5, interval=30, repetitions=10)
+        assert result.repetitions == 0
+        assert result.interval == 1
+
+    def test_q1_ease_factor_drops(self, strategy):
+        """q=1 drops ease factor significantly."""
+        result = strategy.calculate(quality=1, ease_factor=2.5, interval=1, repetitions=0)
+        assert result.ease_factor < 2.0
+
+
+class TestSM2Quality0:
+    """quality=0: Complete blackout."""
+
+    def test_q0_resets(self, strategy):
+        """q=0 resets repetitions and interval."""
+        result = strategy.calculate(quality=0, ease_factor=2.5, interval=60, repetitions=15)
+        assert result.repetitions == 0
+        assert result.interval == 1
+
+    def test_q0_ease_factor_heavily_penalized(self, strategy):
+        """q=0 causes largest ease factor decrease."""
+        result = strategy.calculate(quality=0, ease_factor=2.5, interval=1, repetitions=0)
+        # EF formula: 2.5 + (0.1 - 5*0.08 - 25*0.02) = 2.5 + (0.1 - 0.4 - 0.5) = 2.5 - 0.8 = 1.7
+        assert result.ease_factor == pytest.approx(1.7, abs=0.01)
+
+    def test_q0_clamps_ease_factor(self, strategy):
+        """q=0 from already-low EF clamps at 1.3."""
+        result = strategy.calculate(quality=0, ease_factor=1.3, interval=1, repetitions=0)
+        assert result.ease_factor == SM2Strategy.MIN_EASE_FACTOR
+
+
+class TestSM2InvalidInput:
+    """Tests for invalid quality values."""
+
+    def test_quality_negative(self, strategy):
+        """Negative quality raises ValueError."""
+        with pytest.raises(ValueError, match="Quality must be between 0 and 5"):
+            strategy.calculate(quality=-1, ease_factor=2.5, interval=1, repetitions=0)
+
+    def test_quality_too_high(self, strategy):
+        """Quality > 5 raises ValueError."""
+        with pytest.raises(ValueError, match="Quality must be between 0 and 5"):
+            strategy.calculate(quality=6, ease_factor=2.5, interval=1, repetitions=0)
+
+
+class TestSM2EaseFactorFormula:
+    """Verify the exact SM-2 ease factor formula."""
+
+    @pytest.mark.parametrize(
+        ("quality", "expected_ef_delta"),
+        [
+            (5, 0.10),  # 0.1 - 0*(0.08 + 0*0.02) = 0.1
+            (4, 0.00),  # 0.1 - 1*(0.08 + 1*0.02) = 0.1 - 0.10 = 0.0
+            (3, -0.14),  # 0.1 - 2*(0.08 + 2*0.02) = 0.1 - 0.24 = -0.14
+            (2, -0.32),  # 0.1 - 3*(0.08 + 3*0.02) = 0.1 - 0.42 = -0.32
+            (1, -0.54),  # 0.1 - 4*(0.08 + 4*0.02) = 0.1 - 0.64 = -0.54
+            (0, -0.80),  # 0.1 - 5*(0.08 + 5*0.02) = 0.1 - 0.90 = -0.80
+        ],
+    )
+    def test_ease_factor_delta(self, strategy, quality, expected_ef_delta):
+        """Verify ease factor changes match SM-2 formula exactly."""
+        result = strategy.calculate(quality=quality, ease_factor=2.5, interval=6, repetitions=2)
+        expected = max(SM2Strategy.MIN_EASE_FACTOR, 2.5 + expected_ef_delta)
+        assert result.ease_factor == pytest.approx(expected, abs=0.001)
+
+
+class TestSM2IntervalProgression:
+    """Test the interval progression over multiple reviews."""
+
+    def test_perfect_review_chain(self, strategy):
+        """Simulate a chain of perfect reviews and verify interval growth."""
+        ef = 2.5
+        interval = 1
+        reps = 0
+
+        # First review
+        r = strategy.calculate(quality=5, ease_factor=ef, interval=interval, repetitions=reps)
+        assert r.interval == 1
+        assert r.repetitions == 1
+
+        # Second review
+        r = strategy.calculate(quality=5, ease_factor=r.ease_factor, interval=r.interval, repetitions=r.repetitions)
+        assert r.interval == 6
+        assert r.repetitions == 2
+
+        # Third review (interval should grow significantly)
+        r = strategy.calculate(quality=5, ease_factor=r.ease_factor, interval=r.interval, repetitions=r.repetitions)
+        assert r.interval > 6
+        assert r.repetitions == 3
+
+    def test_failure_resets_progress(self, strategy):
+        """Failing after successful reviews resets to beginning."""
+        # Build up to rep=3
+        ef = 2.5
+        interval = 1
+        reps = 0
+        for _ in range(3):
+            r = strategy.calculate(quality=5, ease_factor=ef, interval=interval, repetitions=reps)
+            ef = r.ease_factor
+            interval = r.interval
+            reps = r.repetitions
+
+        assert reps == 3
+        assert interval > 6
+
+        # Now fail with quality=1
+        r = strategy.calculate(quality=1, ease_factor=ef, interval=interval, repetitions=reps)
+        assert r.repetitions == 0
+        assert r.interval == 1
+
+
+class TestSchedulingResult:
+    """Tests for SchedulingResult dataclass."""
+
+    def test_frozen(self):
+        """SchedulingResult is immutable."""
+        result = SchedulingResult(ease_factor=2.5, interval=1, repetitions=0)
+        with pytest.raises(AttributeError):
+            result.ease_factor = 3.0  # type: ignore[misc]
+
+    def test_slots(self):
+        """SchedulingResult uses __slots__ for memory efficiency."""
+        result = SchedulingResult(ease_factor=2.5, interval=1, repetitions=0)
+        assert not hasattr(result, "__dict__")

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,147 @@
+# データベーススキーマ
+
+## ER図
+
+```mermaid
+erDiagram
+    users {
+        uuid id PK
+        varchar(100) username UK
+        varchar(255) email UK
+        varchar(255) password_hash
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    rooms {
+        uuid id PK
+        uuid owner_id FK
+        varchar(100) name
+        text description
+        jsonb layout_data
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    memory_items {
+        uuid id PK
+        uuid room_id FK
+        text content
+        varchar(2048) image_url
+        float position_x
+        float position_y
+        float position_z
+        float ease_factor
+        integer interval
+        integer repetitions
+        timestamptz last_reviewed_at
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    review_sessions {
+        uuid id PK
+        uuid room_id FK
+        integer total_items
+        integer completed_items
+        timestamptz started_at
+        timestamptz completed_at
+    }
+
+    review_records {
+        uuid id PK
+        uuid session_id FK
+        uuid memory_item_id FK
+        integer quality
+        integer response_time_ms
+        timestamptz reviewed_at
+    }
+
+    users ||--o{ rooms : "owns"
+    rooms ||--o{ memory_items : "contains"
+    rooms ||--o{ review_sessions : "has"
+    review_sessions ||--o{ review_records : "includes"
+    memory_items ||--o{ review_records : "reviewed in"
+```
+
+## テーブル詳細
+
+### users
+ユーザーアカウント情報を管理する。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | UUID | PK | ユーザーID |
+| username | VARCHAR(100) | UNIQUE, NOT NULL | ユーザー名 |
+| email | VARCHAR(255) | UNIQUE, NOT NULL | メールアドレス |
+| password_hash | VARCHAR(255) | NOT NULL | パスワードハッシュ |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 作成日時 |
+| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 更新日時 |
+
+### rooms
+記憶宮殿のルーム（3D空間）を管理する。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | UUID | PK | ルームID |
+| owner_id | UUID | FK(users.id), NOT NULL | 所有者ユーザーID |
+| name | VARCHAR(100) | NOT NULL | ルーム名（1-100文字） |
+| description | TEXT | NULL | ルーム説明 |
+| layout_data | JSONB | NULL | 3Dレイアウトデータ（床、壁、装飾） |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 作成日時 |
+| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 更新日時 |
+
+### memory_items
+ルーム内に配置される記憶アイテム。SM-2 パラメータを保持する。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | UUID | PK | アイテムID |
+| room_id | UUID | FK(rooms.id), NOT NULL | 所属ルームID |
+| content | TEXT | NOT NULL | 記憶対象テキスト（1-10,000文字） |
+| image_url | VARCHAR(2048) | NULL | 画像URL |
+| position_x | FLOAT | NOT NULL, DEFAULT 0.0 | X座標（-1000.0〜1000.0） |
+| position_y | FLOAT | NOT NULL, DEFAULT 0.0 | Y座標（-1000.0〜1000.0） |
+| position_z | FLOAT | NOT NULL, DEFAULT 0.0 | Z座標（-1000.0〜1000.0） |
+| ease_factor | FLOAT | NOT NULL, DEFAULT 2.5 | SM-2 難易度係数（最小 1.3） |
+| interval | INTEGER | NOT NULL, DEFAULT 1 | 復習間隔（日数） |
+| repetitions | INTEGER | NOT NULL, DEFAULT 0 | 連続正答回数 |
+| last_reviewed_at | TIMESTAMPTZ | NULL | 最終復習日時 |
+| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 作成日時 |
+| updated_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 更新日時 |
+
+### review_sessions
+復習セッションを管理する。途中中断時のロールバックに対応。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | UUID | PK | セッションID |
+| room_id | UUID | FK(rooms.id), NOT NULL | 対象ルームID |
+| total_items | INTEGER | NOT NULL, DEFAULT 0 | セッション内の合計アイテム数 |
+| completed_items | INTEGER | NOT NULL, DEFAULT 0 | 完了アイテム数 |
+| started_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | 開始日時 |
+| completed_at | TIMESTAMPTZ | NULL | 完了日時（進行中は NULL） |
+
+### review_records
+復習セッション内の個別レビュー記録。
+
+| カラム | 型 | 制約 | 説明 |
+|---|---|---|---|
+| id | UUID | PK | レコードID |
+| session_id | UUID | FK(review_sessions.id), NOT NULL | 所属セッションID |
+| memory_item_id | UUID | FK(memory_items.id), NOT NULL | 対象アイテムID |
+| quality | INTEGER | NOT NULL | 自己評価（0-5） |
+| response_time_ms | INTEGER | NOT NULL | 回答時間（ミリ秒、上限 300,000） |
+| reviewed_at | TIMESTAMPTZ | NOT NULL, DEFAULT now() | レビュー日時 |
+
+## SM-2 パラメータのデフォルト値
+
+| パラメータ | デフォルト値 | 説明 |
+|---|---|---|
+| ease_factor | 2.5 | 難易度係数。最小 1.3 |
+| interval | 1 | 復習間隔（日数）。初回は 1日 |
+| repetitions | 0 | 連続正答回数。quality < 3 でリセット |
+
+## 外部キー削除ポリシー
+
+全ての外部キーに `ON DELETE CASCADE` を設定。親レコード削除時に関連レコードも自動削除される。

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -36,7 +36,8 @@
 					}
 				},
 				"noForEach": "warn",
-				"useSimplifiedLogicExpression": "warn"
+				"useSimplifiedLogicExpression": "warn",
+				"useLiteralKeys": "off"
 			},
 			"correctness": {
 				"noUnusedImports": "error",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
 			"dependencies": {
 				"react": "^19.0.0",
 				"react-dom": "^19.0.0",
+				"recharts": "^3.8.1",
 				"three": "^0.183.2"
 			},
 			"devDependencies": {
@@ -1398,6 +1399,42 @@
 				"node": ">=14"
 			}
 		},
+		"node_modules/@reduxjs/toolkit": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+			"integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@standard-schema/spec": "^1.0.0",
+				"@standard-schema/utils": "^0.3.0",
+				"immer": "^11.0.0",
+				"redux": "^5.0.1",
+				"redux-thunk": "^3.1.0",
+				"reselect": "^5.1.0"
+			},
+			"peerDependencies": {
+				"react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+				"react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"react": {
+					"optional": true
+				},
+				"react-redux": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@reduxjs/toolkit/node_modules/immer": {
+			"version": "11.1.4",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+			"integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-beta.27",
 			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1755,6 +1792,18 @@
 				"win32"
 			]
 		},
+		"node_modules/@standard-schema/spec": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+			"license": "MIT"
+		},
+		"node_modules/@standard-schema/utils": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+			"integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+			"license": "MIT"
+		},
 		"node_modules/@testing-library/dom": {
 			"version": "10.4.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -1905,6 +1954,69 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/d3-array": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+			"integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-color": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+			"integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-ease": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+			"integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-interpolate": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+			"integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-color": "*"
+			}
+		},
+		"node_modules/@types/d3-path": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+			"integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-scale": {
+			"version": "4.0.9",
+			"resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+			"integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-time": "*"
+			}
+		},
+		"node_modules/@types/d3-shape": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+			"integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/d3-path": "*"
+			}
+		},
+		"node_modules/@types/d3-time": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+			"integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+			"license": "MIT"
+		},
+		"node_modules/@types/d3-timer": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+			"integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+			"license": "MIT"
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1916,7 +2028,7 @@
 			"version": "19.2.14",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
 			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"csstype": "^3.2.2"
@@ -1954,6 +2066,12 @@
 				"fflate": "~0.8.2",
 				"meshoptimizer": "~1.0.1"
 			}
+		},
+		"node_modules/@types/use-sync-external-store": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+			"integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+			"license": "MIT"
 		},
 		"node_modules/@types/webxr": {
 			"version": "0.5.24",
@@ -2291,6 +2409,15 @@
 				"node": ">= 16"
 			}
 		},
+		"node_modules/clsx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2358,8 +2485,129 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
 			"integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
+		},
+		"node_modules/d3-array": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+			"integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+			"license": "ISC",
+			"dependencies": {
+				"internmap": "1 - 2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-color": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+			"integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-ease": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+			"integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-format": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+			"integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-interpolate": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+			"integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-color": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-path": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+			"integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-scale": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+			"integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2.10.0 - 3",
+				"d3-format": "1 - 3",
+				"d3-interpolate": "1.2.0 - 3",
+				"d3-time": "2.1.1 - 3",
+				"d3-time-format": "2 - 4"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-shape": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+			"integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-path": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+			"integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-array": "2 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-time-format": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+			"integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+			"license": "ISC",
+			"dependencies": {
+				"d3-time": "1 - 3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/d3-timer": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+			"integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/data-urls": {
 			"version": "7.0.0",
@@ -2398,6 +2646,12 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/decimal.js-light": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+			"integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
 			"license": "MIT"
 		},
 		"node_modules/deep-eql": {
@@ -2469,6 +2723,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/es-toolkit": {
+			"version": "1.45.1",
+			"resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+			"integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+			"license": "MIT",
+			"workspaces": [
+				"docs",
+				"benchmarks"
+			]
+		},
 		"node_modules/esbuild": {
 			"version": "0.25.12",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -2530,6 +2794,12 @@
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+			"integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+			"license": "MIT"
 		},
 		"node_modules/expect-type": {
 			"version": "1.3.0",
@@ -2693,6 +2963,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/immer": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+			"integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/immer"
+			}
+		},
 		"node_modules/indent-string": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -2701,6 +2981,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/internmap": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+			"integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
@@ -3241,9 +3530,31 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true
+		},
+		"node_modules/react-redux": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/use-sync-external-store": "^0.0.6",
+				"use-sync-external-store": "^1.4.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^18.2.25 || ^19",
+				"react": "^18.0 || ^19",
+				"redux": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"redux": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/react-refresh": {
 			"version": "0.17.0",
@@ -3253,6 +3564,36 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/recharts": {
+			"version": "3.8.1",
+			"resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+			"integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+			"license": "MIT",
+			"workspaces": [
+				"www"
+			],
+			"dependencies": {
+				"@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+				"clsx": "^2.1.1",
+				"decimal.js-light": "^2.5.1",
+				"es-toolkit": "^1.39.3",
+				"eventemitter3": "^5.0.1",
+				"immer": "^10.1.1",
+				"react-redux": "8.x.x || 9.x.x",
+				"reselect": "5.1.1",
+				"tiny-invariant": "^1.3.3",
+				"use-sync-external-store": "^1.2.2",
+				"victory-vendor": "^37.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"node_modules/redent": {
@@ -3269,6 +3610,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/redux": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+			"license": "MIT"
+		},
+		"node_modules/redux-thunk": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+			"integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"redux": "^5.0.0"
+			}
+		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -3278,6 +3634,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/reselect": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+			"integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+			"license": "MIT"
 		},
 		"node_modules/rollup": {
 			"version": "4.60.0",
@@ -3571,6 +3933,12 @@
 			"integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
 			"license": "MIT"
 		},
+		"node_modules/tiny-invariant": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+			"license": "MIT"
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3731,6 +4099,37 @@
 			},
 			"peerDependencies": {
 				"browserslist": ">= 4.21.0"
+			}
+		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/victory-vendor": {
+			"version": "37.3.6",
+			"resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+			"integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+			"license": "MIT AND ISC",
+			"dependencies": {
+				"@types/d3-array": "^3.0.3",
+				"@types/d3-ease": "^3.0.0",
+				"@types/d3-interpolate": "^3.0.1",
+				"@types/d3-scale": "^4.0.2",
+				"@types/d3-shape": "^3.1.0",
+				"@types/d3-time": "^3.0.0",
+				"@types/d3-timer": "^3.0.0",
+				"d3-array": "^3.1.6",
+				"d3-ease": "^3.0.1",
+				"d3-interpolate": "^3.0.1",
+				"d3-scale": "^4.0.2",
+				"d3-shape": "^3.1.0",
+				"d3-time": "^3.0.0",
+				"d3-timer": "^3.0.1"
 			}
 		},
 		"node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
 	"dependencies": {
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0",
+		"recharts": "^3.8.1",
 		"three": "^0.183.2"
 	},
 	"devDependencies": {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,15 +1,125 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "./App";
 
+// Mock the API module
+vi.mock("@/lib/api", () => ({
+	roomApi: {
+		list: vi.fn(),
+		create: vi.fn(),
+		delete: vi.fn(),
+	},
+	itemApi: {
+		list: vi.fn(),
+	},
+}));
+
+// Import mocked module
+const { roomApi } = await import("@/lib/api");
+
+beforeEach(() => {
+	vi.mocked(roomApi.list).mockResolvedValue([]);
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
 describe("App", () => {
-	it("renders the heading", () => {
+	it("renders the heading", async () => {
 		render(<App />);
 		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Memory Palace");
 	});
 
-	it("renders the description text", () => {
+	it("renders the description text", async () => {
 		render(<App />);
 		expect(screen.getByText("記憶宮殿 - 間隔反復学習ツール")).toBeDefined();
+	});
+
+	it("shows empty state when no rooms exist", async () => {
+		vi.mocked(roomApi.list).mockResolvedValue([]);
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("no-rooms-message")).toBeDefined();
+		});
+	});
+
+	it("displays rooms from the API", async () => {
+		vi.mocked(roomApi.list).mockResolvedValue([
+			{
+				id: "room-1",
+				owner_id: "owner-1",
+				name: "My Room",
+				description: null,
+				layout_data: null,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+			},
+		]);
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-list")).toBeDefined();
+			expect(screen.getByText("My Room")).toBeDefined();
+		});
+	});
+
+	it("has a room name input and create button", async () => {
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-name-input")).toBeDefined();
+			expect(screen.getByTestId("create-room-button")).toBeDefined();
+		});
+	});
+
+	it("create button is disabled when input is empty", async () => {
+		render(<App />);
+
+		await waitFor(() => {
+			const button = screen.getByTestId("create-room-button");
+			expect(button).toBeDisabled();
+		});
+	});
+
+	it("creates a room when form is submitted", async () => {
+		const user = userEvent.setup();
+		vi.mocked(roomApi.create).mockResolvedValue({
+			id: "new-room",
+			owner_id: "owner-1",
+			name: "New Room",
+			description: null,
+			layout_data: null,
+			created_at: "2026-01-01T00:00:00Z",
+			updated_at: "2026-01-01T00:00:00Z",
+		});
+
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("room-name-input")).toBeDefined();
+		});
+
+		const input = screen.getByTestId("room-name-input");
+		const button = screen.getByTestId("create-room-button");
+
+		await user.type(input, "New Room");
+		await user.click(button);
+
+		await waitFor(() => {
+			expect(roomApi.create).toHaveBeenCalledWith({ name: "New Room" });
+			expect(screen.getByText("New Room")).toBeDefined();
+		});
+	});
+
+	it("shows error message on API failure", async () => {
+		vi.mocked(roomApi.list).mockRejectedValue(new Error("Network error"));
+		render(<App />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("error-message")).toBeDefined();
+		});
 	});
 });

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -13,6 +13,28 @@ vi.mock("@/lib/api", () => ({
 	itemApi: {
 		list: vi.fn(),
 	},
+	reviewApi: {
+		getQueue: vi.fn(),
+		recordReview: vi.fn(),
+		getStats: vi.fn(),
+		getDailyStats: vi.fn(),
+		getForgettingCurve: vi.fn(),
+	},
+}));
+
+// Mock recharts
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	LineChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	PieChart: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+	Line: () => <div />,
+	Pie: () => <div />,
+	Cell: () => <div />,
+	XAxis: () => <div />,
+	YAxis: () => <div />,
+	CartesianGrid: () => <div />,
+	Tooltip: () => <div />,
+	Legend: () => <div />,
 }));
 
 // Import mocked module

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,227 @@
+import { RoomEditor } from "@/components/RoomEditor";
+import { roomApi } from "@/lib/api";
+import type { Room, RoomCreateRequest } from "@/types/api";
+import { useCallback, useEffect, useState } from "react";
+
+type View = { type: "list" } | { type: "editor"; roomId: string };
+
 export function App(): React.JSX.Element {
+	const [view, setView] = useState<View>({ type: "list" });
+	const [rooms, setRooms] = useState<Room[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [newRoomName, setNewRoomName] = useState("");
+
+	const loadRooms = useCallback(async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			const data = await roomApi.list();
+			setRooms(data);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load rooms");
+		} finally {
+			setLoading(false);
+		}
+	}, []);
+
+	useEffect(() => {
+		loadRooms();
+	}, [loadRooms]);
+
+	const handleCreateRoom = async (): Promise<void> => {
+		const name = newRoomName.trim();
+		if (name.length === 0 || name.length > 100) return;
+
+		try {
+			const body: RoomCreateRequest = { name };
+			const room = await roomApi.create(body);
+			setRooms((prev) => [room, ...prev]);
+			setNewRoomName("");
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to create room");
+		}
+	};
+
+	const handleDeleteRoom = async (roomId: string): Promise<void> => {
+		try {
+			await roomApi.delete(roomId);
+			setRooms((prev) => prev.filter((r) => r.id !== roomId));
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to delete room");
+		}
+	};
+
+	if (view.type === "editor") {
+		return (
+			<div style={{ height: "100vh", display: "flex", flexDirection: "column" }}>
+				<div
+					style={{
+						padding: "8px 16px",
+						backgroundColor: "#0a0a1a",
+						borderBottom: "1px solid #2a2a4a",
+					}}
+				>
+					<button
+						type="button"
+						onClick={() => {
+							setView({ type: "list" });
+							loadRooms();
+						}}
+						style={{
+							padding: "6px 12px",
+							backgroundColor: "#2a2a4a",
+							color: "#e0e0e0",
+							border: "1px solid #3a3a5c",
+							borderRadius: "6px",
+							cursor: "pointer",
+							fontSize: "0.85rem",
+						}}
+						data-testid="back-to-list"
+					>
+						← ルーム一覧に戻る
+					</button>
+				</div>
+				<div style={{ flex: 1, overflow: "hidden" }}>
+					<RoomEditor roomId={view.roomId} />
+				</div>
+			</div>
+		);
+	}
+
 	return (
-		<div>
-			<h1>Memory Palace</h1>
-			<p>記憶宮殿 - 間隔反復学習ツール</p>
+		<div
+			style={{
+				minHeight: "100vh",
+				backgroundColor: "#0a0a1a",
+				color: "#e0e0e0",
+				fontFamily: "system-ui, sans-serif",
+				padding: "40px 20px",
+			}}
+		>
+			<div style={{ maxWidth: "600px", margin: "0 auto" }}>
+				<h1 style={{ fontSize: "1.8rem", marginBottom: "8px" }}>Memory Palace</h1>
+				<p style={{ color: "#888", marginBottom: "32px" }}>記憶宮殿 - 間隔反復学習ツール</p>
+
+				{/* Error */}
+				{error && (
+					<p style={{ color: "#ff4444", marginBottom: "16px" }} data-testid="error-message">
+						{error}
+					</p>
+				)}
+
+				{/* Create room */}
+				<div style={{ marginBottom: "24px" }}>
+					<label
+						htmlFor="room-name-input"
+						style={{ display: "block", marginBottom: "6px", fontSize: "0.9rem", color: "#aaa" }}
+					>
+						新しいルームを作成
+					</label>
+					<div style={{ display: "flex", gap: "8px" }}>
+						<input
+							id="room-name-input"
+							type="text"
+							value={newRoomName}
+							onChange={(e) => setNewRoomName(e.target.value)}
+							placeholder="ルーム名（1-100文字）"
+							maxLength={100}
+							style={{
+								flex: 1,
+								padding: "10px 14px",
+								backgroundColor: "#1a1a2e",
+								border: "1px solid #3a3a5c",
+								borderRadius: "8px",
+								color: "#e0e0e0",
+								fontSize: "0.95rem",
+								outline: "none",
+							}}
+							data-testid="room-name-input"
+						/>
+						<button
+							type="button"
+							onClick={handleCreateRoom}
+							disabled={newRoomName.trim().length === 0}
+							style={{
+								padding: "10px 20px",
+								backgroundColor: newRoomName.trim().length > 0 ? "#0066cc" : "#333",
+								color: newRoomName.trim().length > 0 ? "#fff" : "#666",
+								border: "none",
+								borderRadius: "8px",
+								cursor: newRoomName.trim().length > 0 ? "pointer" : "not-allowed",
+								fontSize: "0.9rem",
+								whiteSpace: "nowrap",
+							}}
+							data-testid="create-room-button"
+						>
+							作成
+						</button>
+					</div>
+				</div>
+
+				{/* Room list */}
+				<h2 style={{ fontSize: "1.1rem", marginBottom: "12px" }}>ルーム一覧</h2>
+
+				{loading ? (
+					<p style={{ color: "#888" }}>読み込み中...</p>
+				) : rooms.length === 0 ? (
+					<p style={{ color: "#666" }} data-testid="no-rooms-message">
+						ルームがありません。上のフォームから作成してください。
+					</p>
+				) : (
+					<ul style={{ listStyle: "none", padding: 0, margin: 0 }} data-testid="room-list">
+						{rooms.map((room) => (
+							<li
+								key={room.id}
+								style={{
+									display: "flex",
+									justifyContent: "space-between",
+									alignItems: "center",
+									padding: "12px 16px",
+									marginBottom: "8px",
+									backgroundColor: "#1a1a2e",
+									borderRadius: "8px",
+									border: "1px solid #2a2a4a",
+								}}
+							>
+								<button
+									type="button"
+									onClick={() => setView({ type: "editor", roomId: room.id })}
+									style={{
+										background: "none",
+										border: "none",
+										color: "#4488ff",
+										cursor: "pointer",
+										fontSize: "1rem",
+										textAlign: "left",
+										flex: 1,
+										padding: 0,
+									}}
+									data-testid={`room-link-${room.id}`}
+								>
+									{room.name}
+								</button>
+								<button
+									type="button"
+									onClick={() => handleDeleteRoom(room.id)}
+									style={{
+										padding: "4px 10px",
+										backgroundColor: "transparent",
+										color: "#cc3333",
+										border: "1px solid #cc3333",
+										borderRadius: "4px",
+										cursor: "pointer",
+										fontSize: "0.8rem",
+									}}
+									data-testid={`delete-room-${room.id}`}
+								>
+									削除
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+			</div>
 		</div>
 	);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,15 @@
+import { ReviewSession } from "@/components/ReviewSession";
 import { RoomEditor } from "@/components/RoomEditor";
+import { StatsDashboard } from "@/components/StatsDashboard";
 import { roomApi } from "@/lib/api";
 import type { Room, RoomCreateRequest } from "@/types/api";
 import { useCallback, useEffect, useState } from "react";
 
-type View = { type: "list" } | { type: "editor"; roomId: string };
+type View =
+	| { type: "list" }
+	| { type: "editor"; roomId: string }
+	| { type: "review"; roomId: string }
+	| { type: "stats"; roomId: string };
 
 export function App(): React.JSX.Element {
 	const [view, setView] = useState<View>({ type: "list" });
@@ -51,6 +57,31 @@ export function App(): React.JSX.Element {
 			setError(err instanceof Error ? err.message : "Failed to delete room");
 		}
 	};
+
+	if (view.type === "review") {
+		return (
+			<ReviewSession
+				roomId={view.roomId}
+				onComplete={() => setView({ type: "stats", roomId: view.roomId })}
+				onBack={() => {
+					setView({ type: "list" });
+					loadRooms();
+				}}
+			/>
+		);
+	}
+
+	if (view.type === "stats") {
+		return (
+			<StatsDashboard
+				roomId={view.roomId}
+				onBack={() => {
+					setView({ type: "list" });
+					loadRooms();
+				}}
+			/>
+		);
+	}
 
 	if (view.type === "editor") {
 		return (
@@ -201,22 +232,56 @@ export function App(): React.JSX.Element {
 								>
 									{room.name}
 								</button>
-								<button
-									type="button"
-									onClick={() => handleDeleteRoom(room.id)}
-									style={{
-										padding: "4px 10px",
-										backgroundColor: "transparent",
-										color: "#cc3333",
-										border: "1px solid #cc3333",
-										borderRadius: "4px",
-										cursor: "pointer",
-										fontSize: "0.8rem",
-									}}
-									data-testid={`delete-room-${room.id}`}
-								>
-									削除
-								</button>
+								<div style={{ display: "flex", gap: "6px" }}>
+									<button
+										type="button"
+										onClick={() => setView({ type: "review", roomId: room.id })}
+										style={{
+											padding: "4px 10px",
+											backgroundColor: "#1a4a2e",
+											color: "#44cc88",
+											border: "1px solid #2a8a4a",
+											borderRadius: "4px",
+											cursor: "pointer",
+											fontSize: "0.8rem",
+										}}
+										data-testid={`review-room-${room.id}`}
+									>
+										復習
+									</button>
+									<button
+										type="button"
+										onClick={() => setView({ type: "stats", roomId: room.id })}
+										style={{
+											padding: "4px 10px",
+											backgroundColor: "#1a2a4a",
+											color: "#4488ff",
+											border: "1px solid #2a4a8a",
+											borderRadius: "4px",
+											cursor: "pointer",
+											fontSize: "0.8rem",
+										}}
+										data-testid={`stats-room-${room.id}`}
+									>
+										統計
+									</button>
+									<button
+										type="button"
+										onClick={() => handleDeleteRoom(room.id)}
+										style={{
+											padding: "4px 10px",
+											backgroundColor: "transparent",
+											color: "#cc3333",
+											border: "1px solid #cc3333",
+											borderRadius: "4px",
+											cursor: "pointer",
+											fontSize: "0.8rem",
+										}}
+										data-testid={`delete-room-${room.id}`}
+									>
+										削除
+									</button>
+								</div>
 							</li>
 						))}
 					</ul>

--- a/frontend/src/components/ReviewSession.test.tsx
+++ b/frontend/src/components/ReviewSession.test.tsx
@@ -1,0 +1,234 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReviewSession } from "./ReviewSession";
+
+// Mock the API module
+vi.mock("@/lib/api", () => ({
+	reviewApi: {
+		getQueue: vi.fn(),
+		recordReview: vi.fn(),
+	},
+}));
+
+const { reviewApi } = await import("@/lib/api");
+
+const mockOnComplete = vi.fn();
+const mockOnBack = vi.fn();
+
+const MOCK_ITEM_1 = {
+	id: "item-1",
+	room_id: "room-1",
+	content: "The capital of Japan is Tokyo",
+	image_url: null,
+	position_x: 1.0,
+	position_y: 0,
+	position_z: 2.0,
+	ease_factor: 2.5,
+	interval: 1,
+	repetitions: 0,
+	last_reviewed_at: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_ITEM_2 = {
+	id: "item-2",
+	room_id: "room-1",
+	content: "Water boils at 100 degrees Celsius",
+	image_url: null,
+	position_x: 3.0,
+	position_y: 0,
+	position_z: -1.0,
+	ease_factor: 2.5,
+	interval: 1,
+	repetitions: 0,
+	last_reviewed_at: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_ITEMS = [MOCK_ITEM_1, MOCK_ITEM_2];
+
+beforeEach(() => {
+	vi.mocked(reviewApi.getQueue).mockResolvedValue([]);
+	vi.mocked(reviewApi.recordReview).mockResolvedValue({
+		id: "review-1",
+		session_id: "session-1",
+		memory_item_id: "item-1",
+		quality: 5,
+		response_time_ms: 1000,
+		reviewed_at: "2026-01-01T00:00:00Z",
+	});
+	mockOnComplete.mockReset();
+	mockOnBack.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("ReviewSession", () => {
+	it("shows loading state initially", () => {
+		vi.mocked(reviewApi.getQueue).mockReturnValue(new Promise(() => {}));
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+		expect(screen.getByTestId("review-loading")).toBeDefined();
+	});
+
+	it("shows empty state when no items to review", async () => {
+		vi.mocked(reviewApi.getQueue).mockResolvedValue([]);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("review-empty")).toBeDefined();
+			expect(screen.getByText("復習するアイテムがありません")).toBeDefined();
+		});
+	});
+
+	it("shows review card when items are available", async () => {
+		vi.mocked(reviewApi.getQueue).mockResolvedValue(MOCK_ITEMS);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("review-active")).toBeDefined();
+			expect(screen.getByTestId("review-card")).toBeDefined();
+			expect(screen.getByText("1 / 2")).toBeDefined();
+		});
+	});
+
+	it("shows content when show button is clicked", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue(MOCK_ITEMS);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("revealed-content")).toBeDefined();
+			expect(screen.getByText("The capital of Japan is Tokyo")).toBeDefined();
+		});
+	});
+
+	it("shows quality buttons after revealing content", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue(MOCK_ITEMS);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+
+		await waitFor(() => {
+			for (let q = 0; q <= 5; q++) {
+				expect(screen.getByTestId(`quality-button-${q}`)).toBeDefined();
+			}
+		});
+	});
+
+	it("records review and advances to next item", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue(MOCK_ITEMS);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+		await user.click(screen.getByTestId("quality-button-5"));
+
+		await waitFor(() => {
+			expect(reviewApi.recordReview).toHaveBeenCalledWith("room-1", {
+				memory_item_id: "item-1",
+				quality: 5,
+				response_time_ms: expect.any(Number),
+			});
+			// Should show next item (2/2)
+			expect(screen.getByText("2 / 2")).toBeDefined();
+		});
+	});
+
+	it("shows completion screen after all items reviewed", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue([MOCK_ITEM_1]);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+		await user.click(screen.getByTestId("quality-button-4"));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("review-complete")).toBeDefined();
+			expect(screen.getByText("復習完了")).toBeDefined();
+		});
+	});
+
+	it("calls onBack when back button is clicked in empty state", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue([]);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("review-back-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("review-back-button"));
+		expect(mockOnBack).toHaveBeenCalledOnce();
+	});
+
+	it("calls onComplete when view stats button is clicked", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue([MOCK_ITEM_1]);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+		await user.click(screen.getByTestId("quality-button-5"));
+
+		await waitFor(() => {
+			expect(screen.getByTestId("view-stats-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("view-stats-button"));
+		expect(mockOnComplete).toHaveBeenCalledOnce();
+	});
+
+	it("shows error state on API failure", async () => {
+		vi.mocked(reviewApi.getQueue).mockRejectedValue(new Error("Network error"));
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("review-error")).toBeDefined();
+		});
+	});
+
+	it("shows correct rate in completion screen", async () => {
+		const user = userEvent.setup();
+		vi.mocked(reviewApi.getQueue).mockResolvedValue([MOCK_ITEM_1]);
+		render(<ReviewSession roomId="room-1" onComplete={mockOnComplete} onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("show-content-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("show-content-button"));
+		await user.click(screen.getByTestId("quality-button-5"));
+
+		await waitFor(() => {
+			expect(screen.getByText("100%")).toBeDefined();
+			expect(screen.getByText("1/1")).toBeDefined();
+		});
+	});
+});

--- a/frontend/src/components/ReviewSession.tsx
+++ b/frontend/src/components/ReviewSession.tsx
@@ -1,0 +1,461 @@
+/**
+ * Review Session component.
+ *
+ * Guides the user through reviewing memory items in a 3D room.
+ * Shows items one-by-one, animates camera to each item position,
+ * and collects quality self-assessment (0-5).
+ */
+
+import { reviewApi } from "@/lib/api";
+import type { MemoryItem } from "@/types/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface ReviewSessionProps {
+	roomId: string;
+	onComplete: () => void;
+	onBack: () => void;
+}
+
+interface ReviewState {
+	queue: MemoryItem[];
+	currentIndex: number;
+	loading: boolean;
+	error: string | null;
+	showContent: boolean;
+	startTime: number;
+	completed: boolean;
+	results: Array<{ itemId: string; quality: number }>;
+}
+
+const QUALITY_LABELS: Record<number, string> = {
+	0: "完全忘却",
+	1: "不正解（見れば分かる）",
+	2: "不正解（簡単に思い出せそう）",
+	3: "正解（かなり困難）",
+	4: "正解（少し迷った）",
+	5: "完璧（即座に想起）",
+};
+
+export function ReviewSession({ roomId, onComplete, onBack }: ReviewSessionProps): React.JSX.Element {
+	const [state, setState] = useState<ReviewState>({
+		queue: [],
+		currentIndex: 0,
+		loading: true,
+		error: null,
+		showContent: false,
+		startTime: Date.now(),
+		completed: false,
+		results: [],
+	});
+
+	const startTimeRef = useRef(Date.now());
+
+	const loadQueue = useCallback(async () => {
+		try {
+			setState((prev) => ({ ...prev, loading: true, error: null }));
+			const queue = await reviewApi.getQueue(roomId);
+			setState((prev) => ({
+				...prev,
+				queue,
+				loading: false,
+				currentIndex: 0,
+				completed: queue.length === 0,
+			}));
+			startTimeRef.current = Date.now();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to load review queue";
+			setState((prev) => ({ ...prev, error: message, loading: false }));
+		}
+	}, [roomId]);
+
+	useEffect(() => {
+		loadQueue();
+	}, [loadQueue]);
+
+	const currentItem: MemoryItem | undefined = state.queue[state.currentIndex];
+
+	const handleShowContent = (): void => {
+		setState((prev) => ({ ...prev, showContent: true }));
+	};
+
+	const handleQualitySelect = async (quality: number): Promise<void> => {
+		if (!currentItem) return;
+
+		const responseTimeMs = Math.min(Date.now() - startTimeRef.current, 300000);
+
+		try {
+			await reviewApi.recordReview(roomId, {
+				memory_item_id: currentItem.id,
+				quality,
+				response_time_ms: Math.max(1, responseTimeMs),
+			});
+
+			const newResults = [...state.results, { itemId: currentItem.id, quality }];
+			const nextIndex = state.currentIndex + 1;
+			const isComplete = nextIndex >= state.queue.length;
+
+			setState((prev) => ({
+				...prev,
+				results: newResults,
+				currentIndex: nextIndex,
+				showContent: false,
+				completed: isComplete,
+			}));
+
+			startTimeRef.current = Date.now();
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to record review";
+			setState((prev) => ({ ...prev, error: message }));
+		}
+	};
+
+	// Loading state
+	if (state.loading) {
+		return (
+			<div style={styles.container} data-testid="review-loading">
+				<p style={styles.statusText}>復習キューを読み込み中...</p>
+			</div>
+		);
+	}
+
+	// Error state
+	if (state.error) {
+		return (
+			<div style={styles.container} data-testid="review-error">
+				<p style={styles.errorText}>{state.error}</p>
+				<button type="button" onClick={onBack} style={styles.backButton}>
+					戻る
+				</button>
+			</div>
+		);
+	}
+
+	// Empty queue
+	if (state.queue.length === 0) {
+		return (
+			<div style={styles.container} data-testid="review-empty">
+				<div style={styles.emptyState}>
+					<h2 style={styles.emptyTitle}>復習するアイテムがありません</h2>
+					<p style={styles.emptyDescription}>全てのアイテムが復習済みです。次の復習日まで待ちましょう。</p>
+					<button type="button" onClick={onBack} style={styles.backButton} data-testid="review-back-button">
+						戻る
+					</button>
+				</div>
+			</div>
+		);
+	}
+
+	// Completed state
+	if (state.completed) {
+		const totalItems = state.results.length;
+		const correctItems = state.results.filter((r) => r.quality >= 3).length;
+		const correctRate = totalItems > 0 ? Math.round((correctItems / totalItems) * 100) : 0;
+
+		return (
+			<div style={styles.container} data-testid="review-complete">
+				<div style={styles.completeCard}>
+					<h2 style={styles.completeTitle}>復習完了</h2>
+					<div style={styles.statsGrid}>
+						<div style={styles.statItem}>
+							<span style={styles.statValue}>{totalItems}</span>
+							<span style={styles.statLabel}>復習数</span>
+						</div>
+						<div style={styles.statItem}>
+							<span style={styles.statValue}>{correctRate}%</span>
+							<span style={styles.statLabel}>正答率</span>
+						</div>
+						<div style={styles.statItem}>
+							<span style={styles.statValue}>
+								{correctItems}/{totalItems}
+							</span>
+							<span style={styles.statLabel}>正解数</span>
+						</div>
+					</div>
+					<div style={styles.buttonRow}>
+						<button type="button" onClick={onComplete} style={styles.primaryButton} data-testid="view-stats-button">
+							統計を見る
+						</button>
+						<button type="button" onClick={onBack} style={styles.backButton} data-testid="review-back-button">
+							ルーム一覧に戻る
+						</button>
+					</div>
+				</div>
+			</div>
+		);
+	}
+
+	// Active review
+	return (
+		<div style={styles.container} data-testid="review-active">
+			{/* Progress bar */}
+			<div style={styles.progressContainer}>
+				<div
+					style={{
+						...styles.progressBar,
+						width: `${(state.currentIndex / state.queue.length) * 100}%`,
+					}}
+				/>
+			</div>
+			<div style={styles.progressText}>
+				{state.currentIndex + 1} / {state.queue.length}
+			</div>
+
+			{/* Item card */}
+			<div style={styles.reviewCard} data-testid="review-card">
+				{/* Item position indicator */}
+				<div style={styles.positionBadge}>
+					位置: ({currentItem?.position_x.toFixed(1)}, {currentItem?.position_z.toFixed(1)})
+				</div>
+
+				{/* Content area */}
+				{!state.showContent ? (
+					<div style={styles.contentHidden}>
+						<p style={styles.hintText}>このアイテムの内容を思い出してください</p>
+						<button
+							type="button"
+							onClick={handleShowContent}
+							style={styles.showButton}
+							data-testid="show-content-button"
+						>
+							答えを見る
+						</button>
+					</div>
+				) : (
+					<div style={styles.contentRevealed} data-testid="revealed-content">
+						<p style={styles.contentText}>{currentItem?.content}</p>
+
+						{/* Quality buttons */}
+						<div style={styles.qualityContainer}>
+							<p style={styles.qualityPrompt}>どの程度思い出せましたか？</p>
+							<div style={styles.qualityGrid}>
+								{([0, 1, 2, 3, 4, 5] as const).map((q) => (
+									<button
+										key={q}
+										type="button"
+										onClick={() => handleQualitySelect(q)}
+										style={{
+											...styles.qualityButton,
+											backgroundColor: q >= 3 ? "#1a4a2e" : "#4a1a1a",
+											borderColor: q >= 3 ? "#2a8a4a" : "#8a2a2a",
+										}}
+										data-testid={`quality-button-${q}`}
+									>
+										<span style={styles.qualityScore}>{q}</span>
+										<span style={styles.qualityLabel}>{QUALITY_LABELS[q]}</span>
+									</button>
+								))}
+							</div>
+						</div>
+					</div>
+				)}
+			</div>
+
+			{/* Back button */}
+			<button type="button" onClick={onBack} style={styles.backButtonSmall} data-testid="review-back-button">
+				中断して戻る
+			</button>
+		</div>
+	);
+}
+
+// =============================================================================
+// Inline styles
+// =============================================================================
+
+const styles = {
+	container: {
+		display: "flex",
+		flexDirection: "column",
+		alignItems: "center",
+		justifyContent: "center",
+		minHeight: "100vh",
+		backgroundColor: "#0a0a1a",
+		color: "#e0e0e0",
+		fontFamily: "system-ui, sans-serif",
+		padding: "20px",
+	},
+	statusText: {
+		color: "#888",
+		fontSize: "1rem",
+	},
+	errorText: {
+		color: "#ff4444",
+		fontSize: "1rem",
+		marginBottom: "16px",
+	},
+	emptyState: {
+		textAlign: "center",
+		maxWidth: "400px",
+	},
+	emptyTitle: {
+		fontSize: "1.4rem",
+		marginBottom: "12px",
+	},
+	emptyDescription: {
+		color: "#888",
+		fontSize: "0.95rem",
+		marginBottom: "24px",
+	},
+	progressContainer: {
+		width: "100%",
+		maxWidth: "600px",
+		height: "6px",
+		backgroundColor: "#2a2a4a",
+		borderRadius: "3px",
+		overflow: "hidden",
+		marginBottom: "8px",
+	},
+	progressBar: {
+		height: "100%",
+		backgroundColor: "#0066cc",
+		borderRadius: "3px",
+		transition: "width 0.3s ease",
+	},
+	progressText: {
+		fontSize: "0.85rem",
+		color: "#888",
+		marginBottom: "24px",
+	},
+	reviewCard: {
+		width: "100%",
+		maxWidth: "600px",
+		backgroundColor: "#1a1a2e",
+		borderRadius: "12px",
+		border: "1px solid #2a2a4a",
+		padding: "24px",
+		marginBottom: "16px",
+	},
+	positionBadge: {
+		fontSize: "0.75rem",
+		color: "#666",
+		marginBottom: "16px",
+	},
+	contentHidden: {
+		textAlign: "center",
+		padding: "32px 0",
+	},
+	hintText: {
+		fontSize: "1.1rem",
+		color: "#aaa",
+		marginBottom: "24px",
+	},
+	showButton: {
+		padding: "12px 32px",
+		backgroundColor: "#0066cc",
+		color: "#fff",
+		border: "none",
+		borderRadius: "8px",
+		cursor: "pointer",
+		fontSize: "1rem",
+	},
+	contentRevealed: {
+		textAlign: "center",
+	},
+	contentText: {
+		fontSize: "1.3rem",
+		fontWeight: 600,
+		marginBottom: "24px",
+		lineHeight: 1.5,
+		wordBreak: "break-word",
+	},
+	qualityContainer: {
+		borderTop: "1px solid #2a2a4a",
+		paddingTop: "16px",
+	},
+	qualityPrompt: {
+		fontSize: "0.9rem",
+		color: "#aaa",
+		marginBottom: "12px",
+	},
+	qualityGrid: {
+		display: "grid",
+		gridTemplateColumns: "repeat(3, 1fr)",
+		gap: "8px",
+	},
+	qualityButton: {
+		display: "flex",
+		flexDirection: "column",
+		alignItems: "center",
+		padding: "10px 6px",
+		border: "1px solid",
+		borderRadius: "8px",
+		cursor: "pointer",
+		color: "#e0e0e0",
+		transition: "opacity 0.15s",
+	},
+	qualityScore: {
+		fontSize: "1.2rem",
+		fontWeight: 700,
+		marginBottom: "4px",
+	},
+	qualityLabel: {
+		fontSize: "0.7rem",
+		color: "#bbb",
+		lineHeight: 1.2,
+	},
+	completeCard: {
+		textAlign: "center",
+		maxWidth: "500px",
+		backgroundColor: "#1a1a2e",
+		borderRadius: "12px",
+		border: "1px solid #2a2a4a",
+		padding: "32px",
+	},
+	completeTitle: {
+		fontSize: "1.5rem",
+		marginBottom: "24px",
+	},
+	statsGrid: {
+		display: "flex",
+		justifyContent: "center",
+		gap: "32px",
+		marginBottom: "32px",
+	},
+	statItem: {
+		display: "flex",
+		flexDirection: "column",
+		alignItems: "center",
+	},
+	statValue: {
+		fontSize: "1.8rem",
+		fontWeight: 700,
+		color: "#4488ff",
+	},
+	statLabel: {
+		fontSize: "0.8rem",
+		color: "#888",
+		marginTop: "4px",
+	},
+	buttonRow: {
+		display: "flex",
+		gap: "12px",
+		justifyContent: "center",
+	},
+	primaryButton: {
+		padding: "12px 24px",
+		backgroundColor: "#0066cc",
+		color: "#fff",
+		border: "none",
+		borderRadius: "8px",
+		cursor: "pointer",
+		fontSize: "0.95rem",
+	},
+	backButton: {
+		padding: "12px 24px",
+		backgroundColor: "#2a2a4a",
+		color: "#e0e0e0",
+		border: "1px solid #3a3a5c",
+		borderRadius: "8px",
+		cursor: "pointer",
+		fontSize: "0.95rem",
+	},
+	backButtonSmall: {
+		padding: "8px 16px",
+		backgroundColor: "transparent",
+		color: "#888",
+		border: "1px solid #3a3a5c",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+	},
+} satisfies Record<string, React.CSSProperties>;

--- a/frontend/src/components/RoomEditor.tsx
+++ b/frontend/src/components/RoomEditor.tsx
@@ -1,0 +1,601 @@
+/**
+ * 3D Room Editor component.
+ *
+ * Integrates Three.js scene with React state management.
+ * Handles room rendering, item placement, selection, and CRUD operations.
+ */
+
+import { itemApi, roomApi } from "@/lib/api";
+import { FirstPersonControls } from "@/lib/three/FirstPersonControls";
+import type { ItemManagerCallbacks } from "@/lib/three/ItemManager";
+import { ItemManager } from "@/lib/three/ItemManager";
+import { RoomScene } from "@/lib/three/RoomScene";
+import type { MemoryItem, Room } from "@/types/api";
+import { useCallback, useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+
+/** Props for the RoomEditor component */
+export interface RoomEditorProps {
+	roomId: string;
+}
+
+interface EditorState {
+	room: Room | null;
+	items: MemoryItem[];
+	selectedItemId: string | null;
+	isPlacementMode: boolean;
+	isPointerLocked: boolean;
+	loading: boolean;
+	error: string | null;
+	newItemContent: string;
+	editContent: string;
+}
+
+const INITIAL_STATE: EditorState = {
+	room: null,
+	items: [],
+	selectedItemId: null,
+	isPlacementMode: false,
+	isPointerLocked: false,
+	loading: true,
+	error: null,
+	newItemContent: "",
+	editContent: "",
+};
+
+export function RoomEditor({ roomId }: RoomEditorProps): React.JSX.Element {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const containerRef = useRef<HTMLDivElement>(null);
+	const sceneRef = useRef<RoomScene | null>(null);
+	const controlsRef = useRef<FirstPersonControls | null>(null);
+	const itemManagerRef = useRef<ItemManager | null>(null);
+
+	const [state, setState] = useState<EditorState>(INITIAL_STATE);
+
+	// Partial state updater
+	const updateState = useCallback((partial: Partial<EditorState>) => {
+		setState((prev) => ({ ...prev, ...partial }));
+	}, []);
+
+	// =========================================================================
+	// Data fetching
+	// =========================================================================
+
+	const loadRoom = useCallback(async () => {
+		try {
+			updateState({ loading: true, error: null });
+			const [room, items] = await Promise.all([roomApi.get(roomId), itemApi.list(roomId)]);
+			updateState({ room, items, loading: false });
+			return { room, items };
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to load room";
+			updateState({ error: message, loading: false });
+			return null;
+		}
+	}, [roomId, updateState]);
+
+	// =========================================================================
+	// Three.js initialization
+	// =========================================================================
+
+	useEffect(() => {
+		const canvas = canvasRef.current;
+		const container = containerRef.current;
+		if (!(canvas && container)) return;
+
+		const roomScene = new RoomScene(canvas);
+		sceneRef.current = roomScene;
+
+		const dimensions = roomScene.getDimensions();
+
+		const controls = new FirstPersonControls(roomScene.camera, canvas, dimensions);
+		controlsRef.current = controls;
+
+		const callbacks: ItemManagerCallbacks = {
+			onItemPlaced: (position: THREE.Vector3) => {
+				setState((prev) => {
+					if (prev.newItemContent.trim().length === 0) return prev;
+					// Will be handled in placement handler
+					return { ...prev, isPlacementMode: false };
+				});
+				handleItemPlaced(position);
+			},
+			onItemSelected: (itemId: string) => {
+				setState((prev) => {
+					const item = prev.items.find((i) => i.id === itemId);
+					return {
+						...prev,
+						selectedItemId: itemId,
+						editContent: item?.content ?? "",
+					};
+				});
+			},
+			onItemDeselected: () => {
+				setState((prev) => ({
+					...prev,
+					selectedItemId: null,
+					editContent: "",
+				}));
+			},
+		};
+
+		const itemMgr = new ItemManager(roomScene.scene, roomScene.camera, dimensions, callbacks);
+		itemManagerRef.current = itemMgr;
+
+		// Start render loop
+		roomScene.start(() => {
+			controls.update();
+			updateState({ isPointerLocked: controls.getIsLocked() });
+		});
+
+		// Handle resize
+		const resizeObserver = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				const { width, height } = entry.contentRect;
+				if (width > 0 && height > 0) {
+					roomScene.handleResize(width, height);
+				}
+			}
+		});
+		resizeObserver.observe(container);
+
+		// Handle mouse events (only when not pointer-locked)
+		const handleMouseMove = (event: MouseEvent): void => {
+			if (controls.getIsLocked()) return;
+			const rect = canvas.getBoundingClientRect();
+			itemMgr.handleMouseMove(event, rect);
+		};
+
+		const handleClick = (event: MouseEvent): void => {
+			if (controls.getIsLocked()) return;
+			const rect = canvas.getBoundingClientRect();
+			itemMgr.handleClick(event, rect);
+		};
+
+		canvas.addEventListener("mousemove", handleMouseMove);
+		canvas.addEventListener("click", handleClick);
+
+		// Load data and sync to 3D scene
+		loadRoom().then((data) => {
+			if (data) {
+				for (const item of data.items) {
+					itemMgr.addItem(item.id, item.content, new THREE.Vector3(item.position_x, 0, item.position_z));
+				}
+			}
+		});
+
+		return () => {
+			canvas.removeEventListener("mousemove", handleMouseMove);
+			canvas.removeEventListener("click", handleClick);
+			resizeObserver.disconnect();
+			controls.disconnect();
+			itemMgr.dispose();
+			roomScene.dispose();
+			sceneRef.current = null;
+			controlsRef.current = null;
+			itemManagerRef.current = null;
+		};
+	}, [loadRoom, updateState]);
+
+	// =========================================================================
+	// Item CRUD handlers
+	// =========================================================================
+
+	const handleItemPlaced = async (position: THREE.Vector3): Promise<void> => {
+		const content = state.newItemContent.trim();
+		if (content.length === 0 || content.length > 500) return;
+
+		try {
+			const newItem = await itemApi.create(roomId, {
+				content,
+				position: { x: position.x, y: position.y, z: position.z },
+			});
+
+			itemManagerRef.current?.addItem(
+				newItem.id,
+				newItem.content,
+				new THREE.Vector3(newItem.position_x, 0, newItem.position_z),
+			);
+
+			updateState({
+				items: [...state.items, newItem],
+				newItemContent: "",
+				isPlacementMode: false,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to create item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleDeleteItem = async (): Promise<void> => {
+		if (!state.selectedItemId) return;
+
+		try {
+			await itemApi.delete(roomId, state.selectedItemId);
+			itemManagerRef.current?.removeItem(state.selectedItemId);
+
+			updateState({
+				items: state.items.filter((i) => i.id !== state.selectedItemId),
+				selectedItemId: null,
+				editContent: "",
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to delete item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleUpdateItem = async (): Promise<void> => {
+		if (!state.selectedItemId) return;
+
+		const content = state.editContent.trim();
+		if (content.length === 0 || content.length > 500) return;
+
+		try {
+			const updatedItem = await itemApi.update(roomId, state.selectedItemId, { content });
+			itemManagerRef.current?.updateItemContent(state.selectedItemId, content);
+
+			updateState({
+				items: state.items.map((i) => (i.id === state.selectedItemId ? updatedItem : i)),
+				editContent: content,
+			});
+		} catch (err) {
+			const message = err instanceof Error ? err.message : "Failed to update item";
+			updateState({ error: message });
+		}
+	};
+
+	const handleStartPlacement = (): void => {
+		if (state.newItemContent.trim().length === 0) return;
+		if (state.newItemContent.trim().length > 500) {
+			updateState({ error: "アイテムテキストは500文字以内です" });
+			return;
+		}
+		itemManagerRef.current?.setPlacementMode(true);
+		updateState({ isPlacementMode: true, selectedItemId: null });
+	};
+
+	const handleCancelPlacement = (): void => {
+		itemManagerRef.current?.setPlacementMode(false);
+		updateState({ isPlacementMode: false });
+	};
+
+	// =========================================================================
+	// Render
+	// =========================================================================
+
+	if (state.loading) {
+		return (
+			<div style={styles.container} data-testid="room-editor-loading">
+				<p>読み込み中...</p>
+			</div>
+		);
+	}
+
+	if (state.error && !state.room) {
+		return (
+			<div style={styles.container} data-testid="room-editor-error">
+				<p style={styles.errorText}>エラー: {state.error}</p>
+			</div>
+		);
+	}
+
+	return (
+		<div style={styles.container} data-testid="room-editor">
+			{/* Header */}
+			<div style={styles.header}>
+				<h2 style={styles.title}>{state.room?.name ?? "Room"}</h2>
+				<span style={styles.itemCount}>アイテム: {state.items.length}件</span>
+			</div>
+
+			{/* 3D Canvas */}
+			<div ref={containerRef} style={styles.canvasContainer}>
+				<canvas ref={canvasRef} style={styles.canvas} data-testid="room-canvas" />
+
+				{/* Pointer lock instruction overlay */}
+				{!(state.isPointerLocked || state.isPlacementMode) && (
+					<div style={styles.overlay} data-testid="pointer-lock-overlay">
+						<p>クリックして3D空間を操作</p>
+						<p style={styles.overlaySubtext}>WASD: 移動 / マウス: 視点</p>
+						<p style={styles.overlaySubtext}>ESC: 操作解除</p>
+					</div>
+				)}
+
+				{/* Placement mode overlay */}
+				{state.isPlacementMode && (
+					<div style={styles.placementOverlay} data-testid="placement-overlay">
+						<p>床をクリックしてアイテムを配置</p>
+						<button type="button" onClick={handleCancelPlacement} style={styles.cancelButton}>
+							キャンセル
+						</button>
+					</div>
+				)}
+			</div>
+
+			{/* Controls Panel */}
+			<div style={styles.panel}>
+				{/* Error message */}
+				{state.error && <p style={styles.errorText}>{state.error}</p>}
+
+				{/* New item input */}
+				<div style={styles.inputGroup}>
+					<label htmlFor="new-item-content" style={styles.label}>
+						新しいアイテム
+					</label>
+					<div style={styles.inputRow}>
+						<input
+							id="new-item-content"
+							type="text"
+							value={state.newItemContent}
+							onChange={(e) => updateState({ newItemContent: e.target.value })}
+							placeholder="記憶したいテキスト（1-500文字）"
+							maxLength={500}
+							style={styles.input}
+							data-testid="new-item-input"
+						/>
+						<button
+							type="button"
+							onClick={handleStartPlacement}
+							disabled={state.newItemContent.trim().length === 0}
+							style={{
+								...styles.button,
+								...(state.newItemContent.trim().length === 0 ? styles.buttonDisabled : {}),
+							}}
+							data-testid="place-item-button"
+						>
+							配置
+						</button>
+					</div>
+				</div>
+
+				{/* Selected item controls */}
+				{state.selectedItemId && (
+					<div style={styles.selectedPanel} data-testid="selected-item-panel">
+						<label htmlFor="edit-item-content" style={styles.label}>
+							選択中のアイテム
+						</label>
+						<div style={styles.inputRow}>
+							<input
+								id="edit-item-content"
+								type="text"
+								value={state.editContent}
+								onChange={(e) => updateState({ editContent: e.target.value })}
+								maxLength={500}
+								style={styles.input}
+								data-testid="edit-item-input"
+							/>
+							<button
+								type="button"
+								onClick={handleUpdateItem}
+								disabled={state.editContent.trim().length === 0}
+								style={styles.button}
+								data-testid="update-item-button"
+							>
+								更新
+							</button>
+							<button
+								type="button"
+								onClick={handleDeleteItem}
+								style={styles.deleteButton}
+								data-testid="delete-item-button"
+							>
+								削除
+							</button>
+						</div>
+					</div>
+				)}
+
+				{/* Items list */}
+				<div style={styles.itemsList}>
+					<h3 style={styles.itemsListTitle}>配置済みアイテム</h3>
+					{state.items.length === 0 ? (
+						<p style={styles.emptyText}>アイテムがありません。上のフォームから追加してください。</p>
+					) : (
+						<ul style={styles.list}>
+							{state.items.map((item) => (
+								<li
+									key={item.id}
+									style={{
+										...styles.listItem,
+										...(item.id === state.selectedItemId ? styles.listItemSelected : {}),
+									}}
+								>
+									<span style={styles.itemText}>{item.content}</span>
+									<span style={styles.itemPosition}>
+										({item.position_x.toFixed(1)}, {item.position_z.toFixed(1)})
+									</span>
+								</li>
+							))}
+						</ul>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// =============================================================================
+// Inline styles (MVP — will be replaced by CSS modules or styled-components)
+// =============================================================================
+
+const styles = {
+	container: {
+		display: "flex",
+		flexDirection: "column",
+		height: "100vh",
+		backgroundColor: "#0a0a1a",
+		color: "#e0e0e0",
+		fontFamily: "system-ui, sans-serif",
+	},
+	header: {
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "space-between",
+		padding: "12px 20px",
+		backgroundColor: "#1a1a2e",
+		borderBottom: "1px solid #2a2a4a",
+	},
+	title: {
+		margin: 0,
+		fontSize: "1.2rem",
+		fontWeight: 600,
+	},
+	itemCount: {
+		fontSize: "0.85rem",
+		color: "#888",
+	},
+	canvasContainer: {
+		position: "relative",
+		flex: 1,
+		minHeight: "300px",
+	},
+	canvas: {
+		display: "block",
+		width: "100%",
+		height: "100%",
+	},
+	overlay: {
+		position: "absolute",
+		top: "50%",
+		left: "50%",
+		transform: "translate(-50%, -50%)",
+		textAlign: "center",
+		padding: "24px",
+		backgroundColor: "rgba(0, 0, 0, 0.7)",
+		borderRadius: "12px",
+		pointerEvents: "none",
+	},
+	overlaySubtext: {
+		fontSize: "0.85rem",
+		color: "#888",
+		margin: "4px 0",
+	},
+	placementOverlay: {
+		position: "absolute",
+		top: "20px",
+		left: "50%",
+		transform: "translateX(-50%)",
+		textAlign: "center",
+		padding: "12px 24px",
+		backgroundColor: "rgba(0, 170, 100, 0.85)",
+		borderRadius: "8px",
+	},
+	panel: {
+		padding: "16px 20px",
+		backgroundColor: "#1a1a2e",
+		borderTop: "1px solid #2a2a4a",
+		maxHeight: "250px",
+		overflowY: "auto",
+	},
+	inputGroup: {
+		marginBottom: "12px",
+	},
+	inputRow: {
+		display: "flex",
+		gap: "8px",
+	},
+	label: {
+		display: "block",
+		marginBottom: "4px",
+		fontSize: "0.85rem",
+		color: "#aaa",
+	},
+	input: {
+		flex: 1,
+		padding: "8px 12px",
+		backgroundColor: "#2a2a4a",
+		border: "1px solid #3a3a5c",
+		borderRadius: "6px",
+		color: "#e0e0e0",
+		fontSize: "0.9rem",
+		outline: "none",
+	},
+	button: {
+		padding: "8px 16px",
+		backgroundColor: "#0066cc",
+		color: "#fff",
+		border: "none",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+		whiteSpace: "nowrap",
+	},
+	buttonDisabled: {
+		backgroundColor: "#333",
+		color: "#666",
+		cursor: "not-allowed",
+	},
+	cancelButton: {
+		padding: "6px 14px",
+		backgroundColor: "transparent",
+		color: "#fff",
+		border: "1px solid #fff",
+		borderRadius: "6px",
+		cursor: "pointer",
+		marginTop: "8px",
+	},
+	deleteButton: {
+		padding: "8px 16px",
+		backgroundColor: "#cc3333",
+		color: "#fff",
+		border: "none",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+	},
+	selectedPanel: {
+		marginBottom: "12px",
+		padding: "12px",
+		backgroundColor: "#2a2a4a",
+		borderRadius: "8px",
+		border: "1px solid #ffaa00",
+	},
+	itemsList: {
+		marginTop: "8px",
+	},
+	itemsListTitle: {
+		margin: "0 0 8px",
+		fontSize: "0.9rem",
+		fontWeight: 600,
+	},
+	emptyText: {
+		fontSize: "0.85rem",
+		color: "#666",
+	},
+	list: {
+		listStyle: "none",
+		margin: 0,
+		padding: 0,
+	},
+	listItem: {
+		display: "flex",
+		justifyContent: "space-between",
+		alignItems: "center",
+		padding: "6px 8px",
+		borderRadius: "4px",
+		marginBottom: "4px",
+		backgroundColor: "#2a2a4a",
+	},
+	listItemSelected: {
+		backgroundColor: "#3a3a5c",
+		border: "1px solid #ffaa00",
+	},
+	itemText: {
+		fontSize: "0.85rem",
+		overflow: "hidden",
+		textOverflow: "ellipsis",
+		whiteSpace: "nowrap",
+		maxWidth: "70%",
+	},
+	itemPosition: {
+		fontSize: "0.75rem",
+		color: "#888",
+		whiteSpace: "nowrap",
+	},
+	errorText: {
+		color: "#ff4444",
+		fontSize: "0.85rem",
+		marginBottom: "8px",
+	},
+} satisfies Record<string, React.CSSProperties>;

--- a/frontend/src/components/StatsDashboard.test.tsx
+++ b/frontend/src/components/StatsDashboard.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StatsDashboard } from "./StatsDashboard";
+
+// Mock recharts to avoid canvas/SVG issues in tests
+vi.mock("recharts", () => ({
+	ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+		<div data-testid="responsive-container">{children}</div>
+	),
+	LineChart: ({ children }: { children: React.ReactNode }) => <div data-testid="line-chart">{children}</div>,
+	PieChart: ({ children }: { children: React.ReactNode }) => <div data-testid="pie-chart">{children}</div>,
+	Line: () => <div data-testid="line" />,
+	Pie: () => <div data-testid="pie" />,
+	Cell: () => <div data-testid="cell" />,
+	XAxis: () => <div />,
+	YAxis: () => <div />,
+	CartesianGrid: () => <div />,
+	Tooltip: () => <div />,
+	Legend: () => <div />,
+}));
+
+// Mock the API module
+vi.mock("@/lib/api", () => ({
+	reviewApi: {
+		getStats: vi.fn(),
+		getDailyStats: vi.fn(),
+		getForgettingCurve: vi.fn(),
+	},
+}));
+
+const { reviewApi } = await import("@/lib/api");
+
+const mockOnBack = vi.fn();
+
+const MOCK_STATS = {
+	total_items: 10,
+	reviewed_items: 7,
+	mastered_items: 3,
+	learning_items: 4,
+	new_items: 3,
+	average_ease_factor: 2.6,
+	total_reviews: 25,
+	average_quality: 3.8,
+	reviews_today: 5,
+};
+
+const MOCK_DAILY = {
+	entries: [
+		{ date: "2026-03-28", review_count: 3, average_quality: 4.0, correct_rate: 100.0 },
+		{ date: "2026-03-29", review_count: 5, average_quality: 3.5, correct_rate: 80.0 },
+	],
+};
+
+const MOCK_CURVES = {
+	items: [
+		{
+			item_id: "item-1",
+			content: "Test item",
+			stability: 2.5,
+			curve: [
+				{ days_since_review: 0, retention: 1.0 },
+				{ days_since_review: 1, retention: 0.67 },
+				{ days_since_review: 2, retention: 0.45 },
+			],
+		},
+	],
+};
+
+beforeEach(() => {
+	vi.mocked(reviewApi.getStats).mockResolvedValue(MOCK_STATS);
+	vi.mocked(reviewApi.getDailyStats).mockResolvedValue(MOCK_DAILY);
+	vi.mocked(reviewApi.getForgettingCurve).mockResolvedValue(MOCK_CURVES);
+	mockOnBack.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("StatsDashboard", () => {
+	it("shows loading state initially", () => {
+		vi.mocked(reviewApi.getStats).mockReturnValue(new Promise(() => {}));
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+		expect(screen.getByTestId("stats-loading")).toBeDefined();
+	});
+
+	it("renders summary cards after loading", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("stats-summary")).toBeDefined();
+			expect(screen.getByText("10")).toBeDefined();
+			expect(screen.getByText("25")).toBeDefined();
+			expect(screen.getByText("5")).toBeDefined();
+			expect(screen.getByText("3.8")).toBeDefined();
+		});
+	});
+
+	it("renders mastery chart", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("mastery-chart")).toBeDefined();
+		});
+	});
+
+	it("renders daily chart", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("daily-chart")).toBeDefined();
+		});
+	});
+
+	it("renders forgetting curve chart", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("forgetting-curve-chart")).toBeDefined();
+		});
+	});
+
+	it("calls onBack when back button is clicked", async () => {
+		const user = userEvent.setup();
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("stats-back-button")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("stats-back-button"));
+		expect(mockOnBack).toHaveBeenCalledOnce();
+	});
+
+	it("shows date range buttons", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("range-7")).toBeDefined();
+			expect(screen.getByTestId("range-14")).toBeDefined();
+			expect(screen.getByTestId("range-30")).toBeDefined();
+			expect(screen.getByTestId("range-90")).toBeDefined();
+		});
+	});
+
+	it("reloads data when date range changes", async () => {
+		const user = userEvent.setup();
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("range-7")).toBeDefined();
+		});
+
+		await user.click(screen.getByTestId("range-7"));
+
+		await waitFor(() => {
+			expect(reviewApi.getDailyStats).toHaveBeenCalledWith("room-1", 7);
+		});
+	});
+
+	it("shows error state on API failure", async () => {
+		vi.mocked(reviewApi.getStats).mockRejectedValue(new Error("Network error"));
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("stats-error")).toBeDefined();
+		});
+	});
+
+	it("hides mastery chart when no items", async () => {
+		vi.mocked(reviewApi.getStats).mockResolvedValue({
+			...MOCK_STATS,
+			total_items: 0,
+			mastered_items: 0,
+			learning_items: 0,
+			new_items: 0,
+		});
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("stats-dashboard")).toBeDefined();
+		});
+
+		expect(screen.queryByTestId("mastery-chart")).toBeNull();
+	});
+
+	it("hides forgetting curve chart when no reviewed items", async () => {
+		vi.mocked(reviewApi.getForgettingCurve).mockResolvedValue({ items: [] });
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("stats-dashboard")).toBeDefined();
+		});
+
+		expect(screen.queryByTestId("forgetting-curve-chart")).toBeNull();
+	});
+
+	it("shows mobile warning", async () => {
+		render(<StatsDashboard roomId="room-1" onBack={mockOnBack} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("mobile-warning")).toBeDefined();
+		});
+	});
+});

--- a/frontend/src/components/StatsDashboard.tsx
+++ b/frontend/src/components/StatsDashboard.tsx
@@ -1,0 +1,432 @@
+/**
+ * Statistics Dashboard component.
+ *
+ * Displays review statistics, daily accuracy charts, room mastery breakdown,
+ * and forgetting curve visualization using Recharts.
+ */
+
+import { reviewApi } from "@/lib/api";
+import type { DailyStatsEntry, ForgettingCurveItem, RoomStatsResponse } from "@/types/api";
+import { useCallback, useEffect, useState } from "react";
+import {
+	CartesianGrid,
+	Cell,
+	Legend,
+	Line,
+	LineChart,
+	Pie,
+	PieChart,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+
+export interface StatsDashboardProps {
+	roomId: string;
+	onBack: () => void;
+}
+
+interface DashboardState {
+	stats: RoomStatsResponse | null;
+	dailyEntries: DailyStatsEntry[];
+	forgettingCurves: ForgettingCurveItem[];
+	loading: boolean;
+	error: string | null;
+	dateRange: number;
+}
+
+const DATE_RANGE_OPTIONS = [7, 14, 30, 90] as const;
+
+const PIE_COLORS = ["#00cc66", "#ffaa00", "#888888"];
+
+export function StatsDashboard({ roomId, onBack }: StatsDashboardProps): React.JSX.Element {
+	const [state, setState] = useState<DashboardState>({
+		stats: null,
+		dailyEntries: [],
+		forgettingCurves: [],
+		loading: true,
+		error: null,
+		dateRange: 30,
+	});
+
+	const loadData = useCallback(
+		async (days: number) => {
+			try {
+				setState((prev) => ({ ...prev, loading: true, error: null }));
+
+				const [stats, daily, curves] = await Promise.all([
+					reviewApi.getStats(roomId),
+					reviewApi.getDailyStats(roomId, days),
+					reviewApi.getForgettingCurve(roomId),
+				]);
+
+				setState((prev) => ({
+					...prev,
+					stats,
+					dailyEntries: daily.entries,
+					forgettingCurves: curves.items,
+					loading: false,
+					dateRange: days,
+				}));
+			} catch (err) {
+				const message = err instanceof Error ? err.message : "Failed to load statistics";
+				setState((prev) => ({ ...prev, error: message, loading: false }));
+			}
+		},
+		[roomId],
+	);
+
+	useEffect(() => {
+		loadData(state.dateRange);
+	}, [loadData, state.dateRange]);
+
+	const handleDateRangeChange = (days: number): void => {
+		loadData(days);
+	};
+
+	if (state.loading) {
+		return (
+			<div style={styles.container} data-testid="stats-loading">
+				<p style={styles.statusText}>統計データを読み込み中...</p>
+			</div>
+		);
+	}
+
+	if (state.error) {
+		return (
+			<div style={styles.container} data-testid="stats-error">
+				<p style={styles.errorText}>{state.error}</p>
+				<button type="button" onClick={onBack} style={styles.backButton}>
+					戻る
+				</button>
+			</div>
+		);
+	}
+
+	const { stats } = state;
+
+	// Prepare pie chart data
+	const masteryData = stats
+		? [
+				{ name: "定着済み", value: stats.mastered_items },
+				{ name: "学習中", value: stats.learning_items },
+				{ name: "未学習", value: stats.new_items },
+			]
+		: [];
+
+	// Filter daily entries with reviews for chart
+	const chartData = state.dailyEntries.map((entry) => ({
+		date: entry.date.slice(5), // MM-DD format
+		review_count: entry.review_count,
+		correct_rate: entry.correct_rate ?? 0,
+		average_quality: entry.average_quality ?? 0,
+	}));
+
+	// Forgetting curve colors
+	const curveColors = ["#4488ff", "#ff8844", "#44cc88", "#cc44ff", "#ffcc44"];
+
+	return (
+		<div style={styles.container} data-testid="stats-dashboard">
+			{/* Header */}
+			<div style={styles.header}>
+				<button type="button" onClick={onBack} style={styles.backButton} data-testid="stats-back-button">
+					← 戻る
+				</button>
+				<h2 style={styles.title}>統計ダッシュボード</h2>
+			</div>
+
+			{/* Summary cards */}
+			{stats && (
+				<div style={styles.summaryGrid} data-testid="stats-summary">
+					<div style={styles.summaryCard}>
+						<span style={styles.summaryValue}>{stats.total_items}</span>
+						<span style={styles.summaryLabel}>総アイテム数</span>
+					</div>
+					<div style={styles.summaryCard}>
+						<span style={styles.summaryValue}>{stats.total_reviews}</span>
+						<span style={styles.summaryLabel}>総復習回数</span>
+					</div>
+					<div style={styles.summaryCard}>
+						<span style={styles.summaryValue}>{stats.reviews_today}</span>
+						<span style={styles.summaryLabel}>今日の復習</span>
+					</div>
+					<div style={styles.summaryCard}>
+						<span style={styles.summaryValue}>
+							{stats.average_quality !== null ? stats.average_quality.toFixed(1) : "-"}
+						</span>
+						<span style={styles.summaryLabel}>平均品質</span>
+					</div>
+				</div>
+			)}
+
+			{/* Mastery breakdown */}
+			{stats && stats.total_items > 0 && (
+				<div style={styles.section} data-testid="mastery-chart">
+					<h3 style={styles.sectionTitle}>記憶定着率</h3>
+					<div style={styles.chartContainer}>
+						<ResponsiveContainer width="100%" height={250}>
+							<PieChart>
+								<Pie
+									data={masteryData}
+									cx="50%"
+									cy="50%"
+									outerRadius={80}
+									dataKey="value"
+									label={({ name, value }: { name?: string; value?: number }) =>
+										value && value > 0 ? `${name ?? ""}: ${value}` : ""
+									}
+								>
+									{masteryData.map((_, index) => (
+										<Cell
+											key={`cell-${masteryData[index]?.name ?? index}`}
+											fill={PIE_COLORS[index % PIE_COLORS.length]}
+										/>
+									))}
+								</Pie>
+								<Tooltip />
+								<Legend />
+							</PieChart>
+						</ResponsiveContainer>
+					</div>
+				</div>
+			)}
+
+			{/* Daily review chart */}
+			<div style={styles.section} data-testid="daily-chart">
+				<div style={styles.sectionHeader}>
+					<h3 style={styles.sectionTitle}>日別復習数・正答率</h3>
+					<div style={styles.dateRangeButtons}>
+						{DATE_RANGE_OPTIONS.map((days) => (
+							<button
+								key={days}
+								type="button"
+								onClick={() => handleDateRangeChange(days)}
+								style={{
+									...styles.rangeButton,
+									...(state.dateRange === days ? styles.rangeButtonActive : {}),
+								}}
+								data-testid={`range-${days}`}
+							>
+								{days}日
+							</button>
+						))}
+					</div>
+				</div>
+				<div style={styles.chartContainer}>
+					<ResponsiveContainer width="100%" height={300}>
+						<LineChart data={chartData}>
+							<CartesianGrid strokeDasharray="3 3" stroke="#2a2a4a" />
+							<XAxis dataKey="date" stroke="#888" tick={{ fontSize: 11 }} interval="preserveStartEnd" />
+							<YAxis yAxisId="left" stroke="#4488ff" tick={{ fontSize: 11 }} />
+							<YAxis yAxisId="right" orientation="right" stroke="#00cc66" tick={{ fontSize: 11 }} domain={[0, 100]} />
+							<Tooltip contentStyle={{ backgroundColor: "#1a1a2e", border: "1px solid #2a2a4a", color: "#e0e0e0" }} />
+							<Legend />
+							<Line
+								yAxisId="left"
+								type="monotone"
+								dataKey="review_count"
+								stroke="#4488ff"
+								name="復習数"
+								dot={false}
+								strokeWidth={2}
+							/>
+							<Line
+								yAxisId="right"
+								type="monotone"
+								dataKey="correct_rate"
+								stroke="#00cc66"
+								name="正答率(%)"
+								dot={false}
+								strokeWidth={2}
+							/>
+						</LineChart>
+					</ResponsiveContainer>
+				</div>
+			</div>
+
+			{/* Forgetting curves */}
+			{state.forgettingCurves.length > 0 && (
+				<div style={styles.section} data-testid="forgetting-curve-chart">
+					<h3 style={styles.sectionTitle}>忘却曲線</h3>
+					<p style={styles.sectionDescription}>R(t) = e^(-t/S) — S(安定度) = interval × ease_factor</p>
+					<div style={styles.chartContainer}>
+						<ResponsiveContainer width="100%" height={300}>
+							<LineChart>
+								<CartesianGrid strokeDasharray="3 3" stroke="#2a2a4a" />
+								<XAxis
+									dataKey="days_since_review"
+									type="number"
+									stroke="#888"
+									tick={{ fontSize: 11 }}
+									label={{ value: "日数", position: "insideBottomRight", offset: -5, fill: "#888" }}
+									domain={["dataMin", "dataMax"]}
+								/>
+								<YAxis
+									stroke="#888"
+									tick={{ fontSize: 11 }}
+									domain={[0, 1]}
+									tickFormatter={(v: number) => `${Math.round(v * 100)}%`}
+									label={{ value: "記憶保持率", angle: -90, position: "insideLeft", fill: "#888" }}
+								/>
+								<Tooltip
+									contentStyle={{ backgroundColor: "#1a1a2e", border: "1px solid #2a2a4a", color: "#e0e0e0" }}
+									formatter={(value: unknown) => `${Math.round(Number(value) * 100)}%`}
+								/>
+								<Legend />
+								{state.forgettingCurves.map((item, index) => (
+									<Line
+										key={item.item_id}
+										data={item.curve}
+										type="monotone"
+										dataKey="retention"
+										stroke={curveColors[index % curveColors.length]}
+										name={item.content.length > 20 ? `${item.content.slice(0, 17)}...` : item.content}
+										dot={false}
+										strokeWidth={2}
+									/>
+								))}
+							</LineChart>
+						</ResponsiveContainer>
+					</div>
+				</div>
+			)}
+
+			{/* Mobile warning */}
+			<div style={styles.mobileWarning} data-testid="mobile-warning">
+				<p>3D復習モードはデスクトップでの利用を推奨します。</p>
+			</div>
+		</div>
+	);
+}
+
+// =============================================================================
+// Inline styles
+// =============================================================================
+
+const styles = {
+	container: {
+		minHeight: "100vh",
+		backgroundColor: "#0a0a1a",
+		color: "#e0e0e0",
+		fontFamily: "system-ui, sans-serif",
+		padding: "20px",
+	},
+	statusText: {
+		color: "#888",
+		fontSize: "1rem",
+		textAlign: "center",
+		paddingTop: "40vh",
+	},
+	errorText: {
+		color: "#ff4444",
+		fontSize: "1rem",
+		textAlign: "center",
+		paddingTop: "40vh",
+	},
+	header: {
+		display: "flex",
+		alignItems: "center",
+		gap: "16px",
+		marginBottom: "24px",
+		maxWidth: "900px",
+		margin: "0 auto 24px auto",
+	},
+	title: {
+		margin: 0,
+		fontSize: "1.4rem",
+		fontWeight: 600,
+	},
+	backButton: {
+		padding: "6px 12px",
+		backgroundColor: "#2a2a4a",
+		color: "#e0e0e0",
+		border: "1px solid #3a3a5c",
+		borderRadius: "6px",
+		cursor: "pointer",
+		fontSize: "0.85rem",
+	},
+	summaryGrid: {
+		display: "grid",
+		gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
+		gap: "12px",
+		maxWidth: "900px",
+		margin: "0 auto 24px auto",
+	},
+	summaryCard: {
+		display: "flex",
+		flexDirection: "column",
+		alignItems: "center",
+		padding: "16px",
+		backgroundColor: "#1a1a2e",
+		borderRadius: "8px",
+		border: "1px solid #2a2a4a",
+	},
+	summaryValue: {
+		fontSize: "1.6rem",
+		fontWeight: 700,
+		color: "#4488ff",
+	},
+	summaryLabel: {
+		fontSize: "0.8rem",
+		color: "#888",
+		marginTop: "4px",
+	},
+	section: {
+		maxWidth: "900px",
+		margin: "0 auto 32px auto",
+		backgroundColor: "#1a1a2e",
+		borderRadius: "12px",
+		border: "1px solid #2a2a4a",
+		padding: "20px",
+	},
+	sectionHeader: {
+		display: "flex",
+		justifyContent: "space-between",
+		alignItems: "center",
+		marginBottom: "16px",
+		flexWrap: "wrap",
+		gap: "8px",
+	},
+	sectionTitle: {
+		margin: 0,
+		fontSize: "1.1rem",
+		fontWeight: 600,
+	},
+	sectionDescription: {
+		fontSize: "0.8rem",
+		color: "#888",
+		marginTop: "4px",
+		marginBottom: "16px",
+	},
+	chartContainer: {
+		width: "100%",
+		minHeight: "250px",
+	},
+	dateRangeButtons: {
+		display: "flex",
+		gap: "6px",
+	},
+	rangeButton: {
+		padding: "4px 10px",
+		backgroundColor: "#2a2a4a",
+		color: "#aaa",
+		border: "1px solid #3a3a5c",
+		borderRadius: "4px",
+		cursor: "pointer",
+		fontSize: "0.8rem",
+	},
+	rangeButtonActive: {
+		backgroundColor: "#0066cc",
+		color: "#fff",
+		borderColor: "#0066cc",
+	},
+	mobileWarning: {
+		maxWidth: "900px",
+		margin: "0 auto",
+		textAlign: "center",
+		padding: "12px",
+		fontSize: "0.8rem",
+		color: "#666",
+	},
+} satisfies Record<string, React.CSSProperties>;

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, itemApi, roomApi } from "./api";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function mockResponse(body: unknown, status = 200): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		json: () => Promise.resolve(body),
+		text: () => Promise.resolve(JSON.stringify(body)),
+		headers: new Headers(),
+		redirected: false,
+		statusText: "OK",
+		type: "basic" as ResponseType,
+		url: "",
+		clone: () => mockResponse(body, status),
+		body: null,
+		bodyUsed: false,
+		arrayBuffer: () => Promise.resolve(new ArrayBuffer(0)),
+		blob: () => Promise.resolve(new Blob()),
+		formData: () => Promise.resolve(new FormData()),
+		bytes: () => Promise.resolve(new Uint8Array()),
+	};
+}
+
+function mockNoContentResponse(): Response {
+	return mockResponse(undefined, 204);
+}
+
+function mockErrorResponse(status: number, message: string): Response {
+	return {
+		...mockResponse(message, status),
+		ok: false,
+		status,
+		text: () => Promise.resolve(message),
+	};
+}
+
+beforeEach(() => {
+	mockFetch.mockReset();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("roomApi", () => {
+	describe("list", () => {
+		it("fetches rooms from /api/rooms", async () => {
+			const rooms = [{ id: "1", name: "Room 1" }];
+			mockFetch.mockResolvedValueOnce(mockResponse(rooms));
+
+			const result = await roomApi.list();
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/rooms",
+				expect.objectContaining({ headers: expect.objectContaining({ "Content-Type": "application/json" }) }),
+			);
+			expect(result).toEqual(rooms);
+		});
+	});
+
+	describe("get", () => {
+		it("fetches a room by ID", async () => {
+			const room = { id: "1", name: "Test Room" };
+			mockFetch.mockResolvedValueOnce(mockResponse(room));
+
+			const result = await roomApi.get("1");
+			expect(result).toEqual(room);
+		});
+	});
+
+	describe("create", () => {
+		it("creates a room with POST", async () => {
+			const newRoom = { id: "1", name: "New Room" };
+			mockFetch.mockResolvedValueOnce(mockResponse(newRoom, 201));
+
+			const result = await roomApi.create({ name: "New Room" });
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				"/api/rooms",
+				expect.objectContaining({
+					method: "POST",
+					body: JSON.stringify({ name: "New Room" }),
+				}),
+			);
+			expect(result).toEqual(newRoom);
+		});
+	});
+
+	describe("update", () => {
+		it("updates a room with PATCH", async () => {
+			const updated = { id: "1", name: "Updated" };
+			mockFetch.mockResolvedValueOnce(mockResponse(updated));
+
+			const result = await roomApi.update("1", { name: "Updated" });
+			expect(result).toEqual(updated);
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes a room", async () => {
+			mockFetch.mockResolvedValueOnce(mockNoContentResponse());
+
+			await roomApi.delete("1");
+
+			expect(mockFetch).toHaveBeenCalledWith("/api/rooms/1", expect.objectContaining({ method: "DELETE" }));
+		});
+	});
+});
+
+describe("itemApi", () => {
+	const roomId = "room-1";
+
+	describe("list", () => {
+		it("fetches items for a room", async () => {
+			const items = [{ id: "i1", content: "Test" }];
+			mockFetch.mockResolvedValueOnce(mockResponse(items));
+
+			const result = await itemApi.list(roomId);
+			expect(result).toEqual(items);
+		});
+	});
+
+	describe("create", () => {
+		it("creates an item with position", async () => {
+			const newItem = { id: "i1", content: "New item", position_x: 1, position_z: 2 };
+			mockFetch.mockResolvedValueOnce(mockResponse(newItem, 201));
+
+			const result = await itemApi.create(roomId, {
+				content: "New item",
+				position: { x: 1, y: 0, z: 2 },
+			});
+
+			expect(result).toEqual(newItem);
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/items`,
+				expect.objectContaining({
+					method: "POST",
+					body: expect.stringContaining("New item"),
+				}),
+			);
+		});
+	});
+
+	describe("update", () => {
+		it("updates an item", async () => {
+			const updated = { id: "i1", content: "Updated" };
+			mockFetch.mockResolvedValueOnce(mockResponse(updated));
+
+			const result = await itemApi.update(roomId, "i1", { content: "Updated" });
+			expect(result).toEqual(updated);
+		});
+	});
+
+	describe("delete", () => {
+		it("deletes an item", async () => {
+			mockFetch.mockResolvedValueOnce(mockNoContentResponse());
+
+			await itemApi.delete(roomId, "i1");
+
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/items/i1`,
+				expect.objectContaining({ method: "DELETE" }),
+			);
+		});
+	});
+});
+
+describe("ApiError", () => {
+	it("is thrown on non-OK responses", async () => {
+		mockFetch.mockResolvedValueOnce(mockErrorResponse(404, "Not found"));
+
+		await expect(roomApi.get("nonexistent")).rejects.toThrow(ApiError);
+	});
+
+	it("includes status code and message", async () => {
+		mockFetch.mockResolvedValueOnce(mockErrorResponse(500, "Internal error"));
+
+		try {
+			await roomApi.get("err");
+			expect.unreachable("Should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(ApiError);
+			if (err instanceof ApiError) {
+				expect(err.status).toBe(500);
+				expect(err.message).toContain("Internal error");
+			}
+		}
+	});
+});

--- a/frontend/src/lib/api.test.ts
+++ b/frontend/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ApiError, itemApi, roomApi } from "./api";
+import { ApiError, itemApi, reviewApi, roomApi } from "./api";
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -166,6 +166,88 @@ describe("itemApi", () => {
 				`/api/rooms/${roomId}/items/i1`,
 				expect.objectContaining({ method: "DELETE" }),
 			);
+		});
+	});
+});
+
+describe("reviewApi", () => {
+	const roomId = "room-1";
+
+	describe("getQueue", () => {
+		it("fetches review queue for a room", async () => {
+			const queue = [{ id: "i1", content: "Test" }];
+			mockFetch.mockResolvedValueOnce(mockResponse(queue));
+
+			const result = await reviewApi.getQueue(roomId);
+			expect(result).toEqual(queue);
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/review-queue`,
+				expect.objectContaining({ headers: expect.objectContaining({ "Content-Type": "application/json" }) }),
+			);
+		});
+	});
+
+	describe("recordReview", () => {
+		it("posts a review result", async () => {
+			const reviewResult = { id: "r1", quality: 5 };
+			mockFetch.mockResolvedValueOnce(mockResponse(reviewResult, 201));
+
+			const result = await reviewApi.recordReview(roomId, {
+				memory_item_id: "item-1",
+				quality: 5,
+				response_time_ms: 1000,
+			});
+
+			expect(result).toEqual(reviewResult);
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/review`,
+				expect.objectContaining({
+					method: "POST",
+					body: expect.stringContaining("item-1"),
+				}),
+			);
+		});
+	});
+
+	describe("getStats", () => {
+		it("fetches room stats", async () => {
+			const stats = { total_items: 10, total_reviews: 25 };
+			mockFetch.mockResolvedValueOnce(mockResponse(stats));
+
+			const result = await reviewApi.getStats(roomId);
+			expect(result).toEqual(stats);
+		});
+	});
+
+	describe("getDailyStats", () => {
+		it("fetches daily stats with days parameter", async () => {
+			const daily = { entries: [] };
+			mockFetch.mockResolvedValueOnce(mockResponse(daily));
+
+			const result = await reviewApi.getDailyStats(roomId, 7);
+			expect(result).toEqual(daily);
+			expect(mockFetch).toHaveBeenCalledWith(
+				`/api/rooms/${roomId}/stats/daily?days=7`,
+				expect.objectContaining({ headers: expect.objectContaining({ "Content-Type": "application/json" }) }),
+			);
+		});
+
+		it("uses default 30 days", async () => {
+			const daily = { entries: [] };
+			mockFetch.mockResolvedValueOnce(mockResponse(daily));
+
+			await reviewApi.getDailyStats(roomId);
+			expect(mockFetch).toHaveBeenCalledWith(`/api/rooms/${roomId}/stats/daily?days=30`, expect.objectContaining({}));
+		});
+	});
+
+	describe("getForgettingCurve", () => {
+		it("fetches forgetting curve data", async () => {
+			const curves = { items: [] };
+			mockFetch.mockResolvedValueOnce(mockResponse(curves));
+
+			const result = await reviewApi.getForgettingCurve(roomId);
+			expect(result).toEqual(curves);
 		});
 	});
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,116 @@
+/**
+ * API client for Memory Palace backend.
+ */
+
+import type {
+	MemoryItem,
+	MemoryItemCreateRequest,
+	MemoryItemUpdateRequest,
+	Room,
+	RoomCreateRequest,
+	RoomUpdateRequest,
+} from "@/types/api";
+
+const BASE_URL = "/api";
+
+class ApiError extends Error {
+	constructor(
+		public readonly status: number,
+		message: string,
+	) {
+		super(message);
+		this.name = "ApiError";
+	}
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+	const response = await fetch(`${BASE_URL}${path}`, {
+		headers: {
+			"Content-Type": "application/json",
+			...options?.headers,
+		},
+		...options,
+	});
+
+	if (!response.ok) {
+		const errorBody = await response.text().catch(() => "Unknown error");
+		throw new ApiError(response.status, `API error ${response.status}: ${errorBody}`);
+	}
+
+	// 204 No Content
+	if (response.status === 204) {
+		return undefined as T;
+	}
+
+	return response.json() as Promise<T>;
+}
+
+// =============================================================================
+// Room API
+// =============================================================================
+
+export const roomApi = {
+	list(): Promise<Room[]> {
+		return request<Room[]>("/rooms");
+	},
+
+	get(roomId: string): Promise<Room> {
+		return request<Room>(`/rooms/${roomId}`);
+	},
+
+	create(data: RoomCreateRequest): Promise<Room> {
+		return request<Room>("/rooms", {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	},
+
+	update(roomId: string, data: RoomUpdateRequest): Promise<Room> {
+		return request<Room>(`/rooms/${roomId}`, {
+			method: "PATCH",
+			body: JSON.stringify(data),
+		});
+	},
+
+	delete(roomId: string): Promise<void> {
+		return request<void>(`/rooms/${roomId}`, {
+			method: "DELETE",
+		});
+	},
+};
+
+// =============================================================================
+// MemoryItem API
+// =============================================================================
+
+export const itemApi = {
+	list(roomId: string): Promise<MemoryItem[]> {
+		return request<MemoryItem[]>(`/rooms/${roomId}/items`);
+	},
+
+	get(roomId: string, itemId: string): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items/${itemId}`);
+	},
+
+	create(roomId: string, data: MemoryItemCreateRequest): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items`, {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	},
+
+	update(roomId: string, itemId: string, data: MemoryItemUpdateRequest): Promise<MemoryItem> {
+		return request<MemoryItem>(`/rooms/${roomId}/items/${itemId}`, {
+			method: "PATCH",
+			body: JSON.stringify(data),
+		});
+	},
+
+	delete(roomId: string, itemId: string): Promise<void> {
+		return request<void>(`/rooms/${roomId}/items/${itemId}`, {
+			method: "DELETE",
+		});
+	},
+};
+
+export { ApiError };

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3,11 +3,16 @@
  */
 
 import type {
+	DailyStatsResponse,
+	ForgettingCurveResponse,
 	MemoryItem,
 	MemoryItemCreateRequest,
 	MemoryItemUpdateRequest,
+	ReviewRecordCreate,
+	ReviewRecordResponse,
 	Room,
 	RoomCreateRequest,
+	RoomStatsResponse,
 	RoomUpdateRequest,
 } from "@/types/api";
 
@@ -110,6 +115,35 @@ export const itemApi = {
 		return request<void>(`/rooms/${roomId}/items/${itemId}`, {
 			method: "DELETE",
 		});
+	},
+};
+
+// =============================================================================
+// Review API
+// =============================================================================
+
+export const reviewApi = {
+	getQueue(roomId: string): Promise<MemoryItem[]> {
+		return request<MemoryItem[]>(`/rooms/${roomId}/review-queue`);
+	},
+
+	recordReview(roomId: string, data: ReviewRecordCreate): Promise<ReviewRecordResponse> {
+		return request<ReviewRecordResponse>(`/rooms/${roomId}/review`, {
+			method: "POST",
+			body: JSON.stringify(data),
+		});
+	},
+
+	getStats(roomId: string): Promise<RoomStatsResponse> {
+		return request<RoomStatsResponse>(`/rooms/${roomId}/stats`);
+	},
+
+	getDailyStats(roomId: string, days = 30): Promise<DailyStatsResponse> {
+		return request<DailyStatsResponse>(`/rooms/${roomId}/stats/daily?days=${days}`);
+	},
+
+	getForgettingCurve(roomId: string): Promise<ForgettingCurveResponse> {
+		return request<ForgettingCurveResponse>(`/rooms/${roomId}/stats/forgetting-curve`);
 	},
 };
 

--- a/frontend/src/lib/roomSerializer.test.ts
+++ b/frontend/src/lib/roomSerializer.test.ts
@@ -1,0 +1,131 @@
+import type { MemoryItem, Room } from "@/types/api";
+import { describe, expect, it } from "vitest";
+import { deserializeRoom, exportRoomJSON, parseRoomJSON, serializeRoom } from "./roomSerializer";
+
+const mockRoom: Room = {
+	id: "room-1",
+	owner_id: "owner-1",
+	name: "Test Room",
+	description: "A test room",
+	layout_data: null,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockItems: MemoryItem[] = [
+	{
+		id: "item-1",
+		room_id: "room-1",
+		content: "Paris is the capital of France",
+		image_url: null,
+		position_x: 1.5,
+		position_y: 0,
+		position_z: 3.0,
+		ease_factor: 2.5,
+		interval: 1,
+		repetitions: 0,
+		last_reviewed_at: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	},
+	{
+		id: "item-2",
+		room_id: "room-1",
+		content: "Tokyo is the capital of Japan",
+		image_url: "https://example.com/tokyo.png",
+		position_x: -2.0,
+		position_y: 0,
+		position_z: 1.5,
+		ease_factor: 2.5,
+		interval: 1,
+		repetitions: 0,
+		last_reviewed_at: null,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+	},
+];
+
+describe("serializeRoom", () => {
+	it("converts room and items to serialized format", () => {
+		const result = serializeRoom(mockRoom, mockItems);
+
+		expect(result.id).toBe("room-1");
+		expect(result.name).toBe("Test Room");
+		expect(result.description).toBe("A test room");
+		expect(result.items).toHaveLength(2);
+		expect(result.items[0]?.position.x).toBe(1.5);
+		expect(result.items[0]?.position.z).toBe(3.0);
+	});
+
+	it("handles empty items list", () => {
+		const result = serializeRoom(mockRoom, []);
+		expect(result.items).toHaveLength(0);
+	});
+
+	it("preserves image_url in serialized items", () => {
+		const result = serializeRoom(mockRoom, mockItems);
+		expect(result.items[0]?.image_url).toBeNull();
+		expect(result.items[1]?.image_url).toBe("https://example.com/tokyo.png");
+	});
+});
+
+describe("deserializeRoom", () => {
+	it("converts serialized data back to room and items", () => {
+		const serialized = serializeRoom(mockRoom, mockItems);
+		const result = deserializeRoom(serialized);
+
+		expect(result.room.name).toBe("Test Room");
+		expect(result.items).toHaveLength(2);
+		expect(result.items[0]?.content).toBe("Paris is the capital of France");
+	});
+});
+
+describe("exportRoomJSON", () => {
+	it("produces valid JSON string", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const parsed: unknown = JSON.parse(json);
+		expect(parsed).toBeDefined();
+		expect(typeof parsed).toBe("object");
+	});
+
+	it("includes room name and items", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const parsed = JSON.parse(json) as Record<string, unknown>;
+		expect(parsed["name"]).toBe("Test Room");
+		expect(Array.isArray(parsed["items"])).toBe(true);
+	});
+});
+
+describe("parseRoomJSON", () => {
+	it("parses valid room JSON", () => {
+		const json = exportRoomJSON(mockRoom, mockItems);
+		const result = parseRoomJSON(json);
+
+		expect(result.name).toBe("Test Room");
+		expect(result.items).toHaveLength(2);
+	});
+
+	it("throws on invalid JSON", () => {
+		expect(() => parseRoomJSON("not json")).toThrow();
+	});
+
+	it("throws on missing name", () => {
+		expect(() => parseRoomJSON('{"items": []}')).toThrow("missing or empty name");
+	});
+
+	it("throws on empty name", () => {
+		expect(() => parseRoomJSON('{"name": "", "items": []}')).toThrow("missing or empty name");
+	});
+
+	it("throws on missing items", () => {
+		expect(() => parseRoomJSON('{"name": "Room"}')).toThrow("items must be an array");
+	});
+
+	it("throws on non-array items", () => {
+		expect(() => parseRoomJSON('{"name": "Room", "items": "not array"}')).toThrow("items must be an array");
+	});
+
+	it("throws on non-object input", () => {
+		expect(() => parseRoomJSON('"just a string"')).toThrow("expected an object");
+	});
+});

--- a/frontend/src/lib/roomSerializer.ts
+++ b/frontend/src/lib/roomSerializer.ts
@@ -1,0 +1,79 @@
+/**
+ * Room data serialization/deserialization utilities.
+ *
+ * Converts between backend API data and Three.js scene representation.
+ */
+
+import type { MemoryItem, Room } from "@/types/api";
+
+/** Serialized room data for JSON export/import */
+export interface SerializedRoom {
+	id: string;
+	name: string;
+	description: string | null;
+	items: SerializedItem[];
+}
+
+export interface SerializedItem {
+	id: string;
+	content: string;
+	position: { x: number; y: number; z: number };
+	image_url: string | null;
+}
+
+/** Convert API room + items to serialized format */
+export function serializeRoom(room: Room, items: MemoryItem[]): SerializedRoom {
+	return {
+		id: room.id,
+		name: room.name,
+		description: room.description,
+		items: items.map((item) => ({
+			id: item.id,
+			content: item.content,
+			position: {
+				x: item.position_x,
+				y: item.position_y,
+				z: item.position_z,
+			},
+			image_url: item.image_url,
+		})),
+	};
+}
+
+/** Convert serialized format back to API-compatible structures */
+export function deserializeRoom(data: SerializedRoom): { room: Partial<Room>; items: SerializedItem[] } {
+	return {
+		room: {
+			id: data.id,
+			name: data.name,
+			description: data.description,
+		},
+		items: data.items,
+	};
+}
+
+/** Export room data as JSON string */
+export function exportRoomJSON(room: Room, items: MemoryItem[]): string {
+	return JSON.stringify(serializeRoom(room, items), null, 2);
+}
+
+/** Parse and validate imported room JSON */
+export function parseRoomJSON(json: string): SerializedRoom {
+	const parsed: unknown = JSON.parse(json);
+
+	if (typeof parsed !== "object" || parsed === null) {
+		throw new Error("Invalid room data: expected an object");
+	}
+
+	const data = parsed as Record<string, unknown>;
+
+	if (typeof data["name"] !== "string" || data["name"].length === 0) {
+		throw new Error("Invalid room data: missing or empty name");
+	}
+
+	if (!Array.isArray(data["items"])) {
+		throw new Error("Invalid room data: items must be an array");
+	}
+
+	return data as unknown as SerializedRoom;
+}

--- a/frontend/src/lib/three/FirstPersonControls.ts
+++ b/frontend/src/lib/three/FirstPersonControls.ts
@@ -1,0 +1,205 @@
+/**
+ * First-person camera controls using PointerLock API.
+ *
+ * WASD movement + mouse look (activated by clicking on the canvas).
+ * Movement is constrained within room boundaries.
+ */
+
+import * as THREE from "three";
+import type { RoomDimensions } from "./RoomScene";
+
+/** Movement speed in units per second */
+const MOVE_SPEED = 5.0;
+
+/** Mouse sensitivity (radians per pixel) */
+const MOUSE_SENSITIVITY = 0.002;
+
+/** Camera height (eye level) */
+const EYE_HEIGHT = 1.6;
+
+/** Margin from walls */
+const WALL_MARGIN = 0.5;
+
+interface KeyState {
+	forward: boolean;
+	backward: boolean;
+	left: boolean;
+	right: boolean;
+}
+
+export class FirstPersonControls {
+	private readonly camera: THREE.PerspectiveCamera;
+	private readonly domElement: HTMLElement;
+	private readonly dimensions: RoomDimensions;
+	private readonly euler: THREE.Euler;
+	private readonly velocity: THREE.Vector3;
+	private readonly direction: THREE.Vector3;
+	private readonly keys: KeyState;
+	private isLocked: boolean;
+	private prevTime: number;
+
+	private readonly onMouseMoveBound: (e: MouseEvent) => void;
+	private readonly onKeyDownBound: (e: KeyboardEvent) => void;
+	private readonly onKeyUpBound: (e: KeyboardEvent) => void;
+	private readonly onPointerLockChangeBound: () => void;
+	private readonly onClickBound: () => void;
+
+	constructor(camera: THREE.PerspectiveCamera, domElement: HTMLElement, dimensions: RoomDimensions) {
+		this.camera = camera;
+		this.domElement = domElement;
+		this.dimensions = dimensions;
+		this.euler = new THREE.Euler(0, 0, 0, "YXZ");
+		this.velocity = new THREE.Vector3();
+		this.direction = new THREE.Vector3();
+		this.keys = { forward: false, backward: false, left: false, right: false };
+		this.isLocked = false;
+		this.prevTime = performance.now();
+
+		this.onMouseMoveBound = this.onMouseMove.bind(this);
+		this.onKeyDownBound = this.onKeyDown.bind(this);
+		this.onKeyUpBound = this.onKeyUp.bind(this);
+		this.onPointerLockChangeBound = this.onPointerLockChange.bind(this);
+		this.onClickBound = this.onClick.bind(this);
+
+		this.connect();
+	}
+
+	private connect(): void {
+		document.addEventListener("mousemove", this.onMouseMoveBound);
+		document.addEventListener("keydown", this.onKeyDownBound);
+		document.addEventListener("keyup", this.onKeyUpBound);
+		document.addEventListener("pointerlockchange", this.onPointerLockChangeBound);
+		this.domElement.addEventListener("click", this.onClickBound);
+	}
+
+	disconnect(): void {
+		document.removeEventListener("mousemove", this.onMouseMoveBound);
+		document.removeEventListener("keydown", this.onKeyDownBound);
+		document.removeEventListener("keyup", this.onKeyUpBound);
+		document.removeEventListener("pointerlockchange", this.onPointerLockChangeBound);
+		this.domElement.removeEventListener("click", this.onClickBound);
+
+		if (document.pointerLockElement === this.domElement) {
+			document.exitPointerLock();
+		}
+	}
+
+	private onClick(): void {
+		this.domElement.requestPointerLock();
+	}
+
+	private onPointerLockChange(): void {
+		this.isLocked = document.pointerLockElement === this.domElement;
+		if (!this.isLocked) {
+			this.keys.forward = false;
+			this.keys.backward = false;
+			this.keys.left = false;
+			this.keys.right = false;
+		}
+	}
+
+	private onMouseMove(event: MouseEvent): void {
+		if (!this.isLocked) return;
+
+		this.euler.setFromQuaternion(this.camera.quaternion);
+		this.euler.y -= event.movementX * MOUSE_SENSITIVITY;
+		this.euler.x -= event.movementY * MOUSE_SENSITIVITY;
+		// Clamp vertical look to prevent flipping
+		this.euler.x = Math.max(-Math.PI / 2 + 0.01, Math.min(Math.PI / 2 - 0.01, this.euler.x));
+
+		this.camera.quaternion.setFromEuler(this.euler);
+	}
+
+	private onKeyDown(event: KeyboardEvent): void {
+		if (!this.isLocked) return;
+
+		switch (event.code) {
+			case "KeyW":
+			case "ArrowUp":
+				this.keys.forward = true;
+				break;
+			case "KeyS":
+			case "ArrowDown":
+				this.keys.backward = true;
+				break;
+			case "KeyA":
+			case "ArrowLeft":
+				this.keys.left = true;
+				break;
+			case "KeyD":
+			case "ArrowRight":
+				this.keys.right = true;
+				break;
+		}
+	}
+
+	private onKeyUp(event: KeyboardEvent): void {
+		switch (event.code) {
+			case "KeyW":
+			case "ArrowUp":
+				this.keys.forward = false;
+				break;
+			case "KeyS":
+			case "ArrowDown":
+				this.keys.backward = false;
+				break;
+			case "KeyA":
+			case "ArrowLeft":
+				this.keys.left = false;
+				break;
+			case "KeyD":
+			case "ArrowRight":
+				this.keys.right = false;
+				break;
+		}
+	}
+
+	/** Update camera position based on key state. Call each frame. */
+	update(): void {
+		const time = performance.now();
+		const delta = (time - this.prevTime) / 1000;
+		this.prevTime = time;
+
+		if (!this.isLocked) return;
+
+		// Apply friction
+		this.velocity.x -= this.velocity.x * 10.0 * delta;
+		this.velocity.z -= this.velocity.z * 10.0 * delta;
+
+		// Calculate direction
+		this.direction.z = Number(this.keys.forward) - Number(this.keys.backward);
+		this.direction.x = Number(this.keys.right) - Number(this.keys.left);
+		this.direction.normalize();
+
+		if (this.keys.forward || this.keys.backward) {
+			this.velocity.z -= this.direction.z * MOVE_SPEED * delta;
+		}
+		if (this.keys.left || this.keys.right) {
+			this.velocity.x -= this.direction.x * MOVE_SPEED * delta;
+		}
+
+		// Move camera
+		const forward = new THREE.Vector3();
+		this.camera.getWorldDirection(forward);
+		forward.y = 0;
+		forward.normalize();
+
+		const right = new THREE.Vector3();
+		right.crossVectors(this.camera.up, forward).normalize();
+
+		this.camera.position.addScaledVector(forward, -this.velocity.z * delta);
+		this.camera.position.addScaledVector(right, -this.velocity.x * delta);
+
+		// Constrain to room boundaries
+		const halfWidth = this.dimensions.width / 2 - WALL_MARGIN;
+		const halfDepth = this.dimensions.depth / 2 - WALL_MARGIN;
+		this.camera.position.x = Math.max(-halfWidth, Math.min(halfWidth, this.camera.position.x));
+		this.camera.position.z = Math.max(-halfDepth, Math.min(halfDepth, this.camera.position.z));
+		this.camera.position.y = EYE_HEIGHT;
+	}
+
+	/** Check if pointer is currently locked */
+	getIsLocked(): boolean {
+		return this.isLocked;
+	}
+}

--- a/frontend/src/lib/three/ItemManager.ts
+++ b/frontend/src/lib/three/ItemManager.ts
@@ -1,0 +1,416 @@
+/**
+ * Manages 3D memory item objects in the room scene.
+ *
+ * Handles creation, selection, movement, and deletion of item markers.
+ * Uses Raycaster for click-based interaction.
+ */
+
+import * as THREE from "three";
+import type { RoomDimensions } from "./RoomScene";
+
+/** Visual representation of a memory item in 3D space */
+export interface Item3D {
+	id: string;
+	content: string;
+	mesh: THREE.Mesh;
+	label: THREE.Sprite;
+	group: THREE.Group;
+}
+
+/** Callback types for item events */
+export interface ItemManagerCallbacks {
+	onItemPlaced?: (position: THREE.Vector3) => void;
+	onItemSelected?: (itemId: string) => void;
+	onItemDeselected?: () => void;
+}
+
+/** Item marker geometry constants */
+const MARKER_RADIUS = 0.2;
+const MARKER_HEIGHT = 0.5;
+const MARKER_SEGMENTS = 8;
+const LABEL_SCALE = 0.8;
+const LABEL_Y_OFFSET = 0.8;
+
+/** Colors */
+const COLOR_DEFAULT = 0x00aaff;
+const COLOR_SELECTED = 0xffaa00;
+const COLOR_HOVER = 0x44ccff;
+
+export class ItemManager {
+	private readonly scene: THREE.Scene;
+	private readonly camera: THREE.PerspectiveCamera;
+	private readonly raycaster: THREE.Raycaster;
+	private readonly mouse: THREE.Vector2;
+	private readonly dimensions: RoomDimensions;
+	private readonly items: Map<string, Item3D>;
+	private readonly callbacks: ItemManagerCallbacks;
+
+	private selectedItemId: string | null = null;
+	private hoveredItemId: string | null = null;
+	private placementMode = false;
+
+	/** Placement indicator (crosshair on the floor) */
+	private readonly placementIndicator: THREE.Mesh;
+
+	constructor(
+		scene: THREE.Scene,
+		camera: THREE.PerspectiveCamera,
+		dimensions: RoomDimensions,
+		callbacks: ItemManagerCallbacks = {},
+	) {
+		this.scene = scene;
+		this.camera = camera;
+		this.raycaster = new THREE.Raycaster();
+		this.mouse = new THREE.Vector2();
+		this.dimensions = dimensions;
+		this.items = new Map();
+		this.callbacks = callbacks;
+
+		// Create placement indicator (hidden by default)
+		const indicatorGeo = new THREE.RingGeometry(0.15, 0.25, 16);
+		const indicatorMat = new THREE.MeshBasicMaterial({
+			color: 0x00ff88,
+			side: THREE.DoubleSide,
+			transparent: true,
+			opacity: 0.7,
+		});
+		this.placementIndicator = new THREE.Mesh(indicatorGeo, indicatorMat);
+		this.placementIndicator.rotation.x = -Math.PI / 2;
+		this.placementIndicator.visible = false;
+		this.scene.add(this.placementIndicator);
+	}
+
+	/** Add a memory item to the scene */
+	addItem(id: string, content: string, position: THREE.Vector3): Item3D {
+		const group = new THREE.Group();
+		group.position.copy(position);
+
+		// Marker mesh (cylinder with sphere on top)
+		const markerGeo = new THREE.CylinderGeometry(MARKER_RADIUS * 0.5, MARKER_RADIUS, MARKER_HEIGHT, MARKER_SEGMENTS);
+		const markerMat = new THREE.MeshStandardMaterial({
+			color: COLOR_DEFAULT,
+			emissive: COLOR_DEFAULT,
+			emissiveIntensity: 0.3,
+			roughness: 0.4,
+			metalness: 0.6,
+		});
+		const mesh = new THREE.Mesh(markerGeo, markerMat);
+		mesh.position.y = MARKER_HEIGHT / 2;
+		mesh.castShadow = true;
+		mesh.userData["itemId"] = id;
+		group.add(mesh);
+
+		// Sphere top cap
+		const sphereGeo = new THREE.SphereGeometry(MARKER_RADIUS * 0.6, MARKER_SEGMENTS, MARKER_SEGMENTS);
+		const sphere = new THREE.Mesh(sphereGeo, markerMat);
+		sphere.position.y = MARKER_HEIGHT;
+		sphere.castShadow = true;
+		sphere.userData["itemId"] = id;
+		group.add(sphere);
+
+		// Text label sprite
+		const label = this.createLabelSprite(content);
+		label.position.y = MARKER_HEIGHT + LABEL_Y_OFFSET;
+		group.add(label);
+
+		this.scene.add(group);
+
+		const item3D: Item3D = { id, content, mesh, label, group };
+		this.items.set(id, item3D);
+		return item3D;
+	}
+
+	/** Remove a memory item from the scene */
+	removeItem(id: string): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		if (this.selectedItemId === id) {
+			this.selectedItemId = null;
+			this.callbacks.onItemDeselected?.();
+		}
+
+		this.scene.remove(item.group);
+
+		// Dispose geometries and materials
+		item.group.traverse((child) => {
+			if (child instanceof THREE.Mesh) {
+				child.geometry.dispose();
+				if (Array.isArray(child.material)) {
+					for (const mat of child.material) {
+						mat.dispose();
+					}
+				} else {
+					child.material.dispose();
+				}
+			}
+			if (child instanceof THREE.Sprite) {
+				child.material.map?.dispose();
+				child.material.dispose();
+			}
+		});
+
+		this.items.delete(id);
+		return true;
+	}
+
+	/** Update item position */
+	moveItem(id: string, position: THREE.Vector3): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		const clampedPos = this.clampToRoom(position);
+		item.group.position.copy(clampedPos);
+		return true;
+	}
+
+	/** Update item label text */
+	updateItemContent(id: string, content: string): boolean {
+		const item = this.items.get(id);
+		if (!item) return false;
+
+		// Remove old label
+		item.group.remove(item.label);
+		item.label.material.map?.dispose();
+		item.label.material.dispose();
+
+		// Create new label
+		const newLabel = this.createLabelSprite(content);
+		newLabel.position.y = MARKER_HEIGHT + LABEL_Y_OFFSET;
+		item.group.add(newLabel);
+		item.label = newLabel;
+		item.content = content;
+
+		return true;
+	}
+
+	/** Handle mouse move for hover effects and placement indicator */
+	handleMouseMove(event: MouseEvent, canvasRect: DOMRect): void {
+		this.mouse.x = ((event.clientX - canvasRect.left) / canvasRect.width) * 2 - 1;
+		this.mouse.y = -((event.clientY - canvasRect.top) / canvasRect.height) * 2 + 1;
+
+		if (this.placementMode) {
+			this.updatePlacementIndicator();
+		} else {
+			this.updateHover();
+		}
+	}
+
+	/** Handle click for item selection or placement */
+	handleClick(event: MouseEvent, canvasRect: DOMRect): void {
+		this.mouse.x = ((event.clientX - canvasRect.left) / canvasRect.width) * 2 - 1;
+		this.mouse.y = -((event.clientY - canvasRect.top) / canvasRect.height) * 2 + 1;
+
+		if (this.placementMode) {
+			this.handlePlacement();
+			return;
+		}
+
+		this.handleSelection();
+	}
+
+	/** Toggle placement mode */
+	setPlacementMode(enabled: boolean): void {
+		this.placementMode = enabled;
+		this.placementIndicator.visible = false;
+
+		if (enabled && this.selectedItemId) {
+			this.deselectItem();
+		}
+	}
+
+	/** Get whether in placement mode */
+	isInPlacementMode(): boolean {
+		return this.placementMode;
+	}
+
+	/** Get currently selected item ID */
+	getSelectedItemId(): string | null {
+		return this.selectedItemId;
+	}
+
+	/** Get all items */
+	getAllItems(): ReadonlyMap<string, Item3D> {
+		return this.items;
+	}
+
+	/** Get item position */
+	getItemPosition(id: string): THREE.Vector3 | null {
+		const item = this.items.get(id);
+		return item ? item.group.position.clone() : null;
+	}
+
+	/** Dispose all resources */
+	dispose(): void {
+		for (const [id] of this.items) {
+			this.removeItem(id);
+		}
+		this.placementIndicator.geometry.dispose();
+		if (this.placementIndicator.material instanceof THREE.Material) {
+			this.placementIndicator.material.dispose();
+		}
+	}
+
+	// =========================================================================
+	// Private methods
+	// =========================================================================
+
+	private createLabelSprite(text: string): THREE.Sprite {
+		const canvas = document.createElement("canvas");
+		const ctx = canvas.getContext("2d");
+		if (!ctx) {
+			throw new Error("Failed to create 2D canvas context for label");
+		}
+
+		canvas.width = 256;
+		canvas.height = 64;
+
+		// Background
+		ctx.fillStyle = "rgba(0, 0, 0, 0.7)";
+		ctx.roundRect(0, 0, canvas.width, canvas.height, 8);
+		ctx.fill();
+
+		// Text (truncate to fit)
+		ctx.fillStyle = "#ffffff";
+		ctx.font = "bold 20px sans-serif";
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+
+		const displayText = text.length > 25 ? `${text.substring(0, 22)}...` : text;
+		ctx.fillText(displayText, canvas.width / 2, canvas.height / 2);
+
+		const texture = new THREE.CanvasTexture(canvas);
+		const material = new THREE.SpriteMaterial({ map: texture, transparent: true });
+		const sprite = new THREE.Sprite(material);
+		sprite.scale.set(LABEL_SCALE * (canvas.width / canvas.height), LABEL_SCALE, 1);
+
+		return sprite;
+	}
+
+	private getFloorIntersection(): THREE.Vector3 | null {
+		this.raycaster.setFromCamera(this.mouse, this.camera);
+
+		// Intersect with the floor plane (y = 0)
+		const floorPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
+		const target = new THREE.Vector3();
+		const hit = this.raycaster.ray.intersectPlane(floorPlane, target);
+
+		if (!hit) return null;
+		return this.clampToRoom(target);
+	}
+
+	private getItemIntersection(): string | null {
+		this.raycaster.setFromCamera(this.mouse, this.camera);
+
+		const meshes: THREE.Object3D[] = [];
+		for (const item of this.items.values()) {
+			item.group.traverse((child) => {
+				if (child instanceof THREE.Mesh) {
+					meshes.push(child);
+				}
+			});
+		}
+
+		const intersects = this.raycaster.intersectObjects(meshes);
+		if (intersects.length > 0) {
+			const hitObject = intersects[0]?.object;
+			const itemId = hitObject?.userData?.["itemId"] as string | undefined;
+			return itemId ?? null;
+		}
+		return null;
+	}
+
+	private updatePlacementIndicator(): void {
+		const point = this.getFloorIntersection();
+		if (point) {
+			this.placementIndicator.position.set(point.x, 0.02, point.z);
+			this.placementIndicator.visible = true;
+		} else {
+			this.placementIndicator.visible = false;
+		}
+	}
+
+	private updateHover(): void {
+		const hitId = this.getItemIntersection();
+
+		// Unhover previous
+		if (this.hoveredItemId && this.hoveredItemId !== hitId) {
+			const prev = this.items.get(this.hoveredItemId);
+			if (prev && this.hoveredItemId !== this.selectedItemId) {
+				this.setItemColor(prev, COLOR_DEFAULT);
+			}
+			this.hoveredItemId = null;
+		}
+
+		// Hover new
+		if (hitId && hitId !== this.selectedItemId) {
+			const item = this.items.get(hitId);
+			if (item) {
+				this.setItemColor(item, COLOR_HOVER);
+				this.hoveredItemId = hitId;
+			}
+		}
+	}
+
+	private handlePlacement(): void {
+		const point = this.getFloorIntersection();
+		if (point) {
+			this.placementMode = false;
+			this.placementIndicator.visible = false;
+			this.callbacks.onItemPlaced?.(point);
+		}
+	}
+
+	private handleSelection(): void {
+		const hitId = this.getItemIntersection();
+
+		if (hitId) {
+			// Select item
+			if (this.selectedItemId && this.selectedItemId !== hitId) {
+				this.deselectItem();
+			}
+			const item = this.items.get(hitId);
+			if (item) {
+				this.selectedItemId = hitId;
+				this.setItemColor(item, COLOR_SELECTED);
+				this.callbacks.onItemSelected?.(hitId);
+			}
+		} else if (this.selectedItemId) {
+			// Deselect
+			this.deselectItem();
+		}
+	}
+
+	private deselectItem(): void {
+		if (this.selectedItemId) {
+			const item = this.items.get(this.selectedItemId);
+			if (item) {
+				this.setItemColor(item, COLOR_DEFAULT);
+			}
+			this.selectedItemId = null;
+			this.callbacks.onItemDeselected?.();
+		}
+	}
+
+	private setItemColor(item: Item3D, color: number): void {
+		item.group.traverse((child) => {
+			if (child instanceof THREE.Mesh) {
+				const mat = child.material;
+				if (mat instanceof THREE.MeshStandardMaterial) {
+					mat.color.setHex(color);
+					mat.emissive.setHex(color);
+				}
+			}
+		});
+	}
+
+	private clampToRoom(position: THREE.Vector3): THREE.Vector3 {
+		const halfWidth = this.dimensions.width / 2 - 0.3;
+		const halfDepth = this.dimensions.depth / 2 - 0.3;
+		return new THREE.Vector3(
+			Math.max(-halfWidth, Math.min(halfWidth, position.x)),
+			0,
+			Math.max(-halfDepth, Math.min(halfDepth, position.z)),
+		);
+	}
+}

--- a/frontend/src/lib/three/RoomScene.ts
+++ b/frontend/src/lib/three/RoomScene.ts
@@ -1,0 +1,179 @@
+/**
+ * Three.js room scene manager.
+ *
+ * Handles renderer, camera, scene, lighting, and room geometry.
+ * Designed for first-person navigation using PointerLockControls-like behavior.
+ */
+
+import * as THREE from "three";
+
+/** Room geometry dimensions */
+export interface RoomDimensions {
+	width: number;
+	height: number;
+	depth: number;
+}
+
+/** Default room dimensions */
+const DEFAULT_DIMENSIONS: RoomDimensions = {
+	width: 20,
+	height: 4,
+	depth: 20,
+};
+
+export class RoomScene {
+	readonly scene: THREE.Scene;
+	readonly camera: THREE.PerspectiveCamera;
+	readonly renderer: THREE.WebGLRenderer;
+
+	private animationId: number | null = null;
+	private readonly dimensions: RoomDimensions;
+
+	constructor(canvas: HTMLCanvasElement, dimensions?: Partial<RoomDimensions>) {
+		this.dimensions = { ...DEFAULT_DIMENSIONS, ...dimensions };
+
+		// Scene
+		this.scene = new THREE.Scene();
+		this.scene.background = new THREE.Color(0x1a1a2e);
+		this.scene.fog = new THREE.Fog(0x1a1a2e, 15, 35);
+
+		// Camera
+		this.camera = new THREE.PerspectiveCamera(70, canvas.clientWidth / canvas.clientHeight, 0.1, 100);
+		this.camera.position.set(0, 1.6, this.dimensions.depth / 2 - 1);
+
+		// Renderer
+		this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+		this.renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+		this.renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+		this.renderer.shadowMap.enabled = true;
+		this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+
+		this.setupLighting();
+		this.buildRoom();
+	}
+
+	private setupLighting(): void {
+		// Ambient
+		const ambient = new THREE.AmbientLight(0x404060, 0.6);
+		this.scene.add(ambient);
+
+		// Main directional light
+		const directional = new THREE.DirectionalLight(0xffffff, 0.8);
+		directional.position.set(5, this.dimensions.height - 0.5, 5);
+		directional.castShadow = true;
+		directional.shadow.mapSize.width = 1024;
+		directional.shadow.mapSize.height = 1024;
+		this.scene.add(directional);
+
+		// Fill light
+		const fill = new THREE.PointLight(0x8888ff, 0.3, 30);
+		fill.position.set(-3, this.dimensions.height - 1, -3);
+		this.scene.add(fill);
+	}
+
+	private buildRoom(): void {
+		const { width, height, depth } = this.dimensions;
+
+		// Floor
+		const floorGeometry = new THREE.PlaneGeometry(width, depth);
+		const floorMaterial = new THREE.MeshStandardMaterial({
+			color: 0x2a2a4a,
+			roughness: 0.8,
+			metalness: 0.2,
+		});
+		const floor = new THREE.Mesh(floorGeometry, floorMaterial);
+		floor.rotation.x = -Math.PI / 2;
+		floor.receiveShadow = true;
+		floor.userData["type"] = "floor";
+		this.scene.add(floor);
+
+		// Grid helper on floor
+		const grid = new THREE.GridHelper(width, width, 0x444466, 0x333355);
+		grid.position.y = 0.01;
+		this.scene.add(grid);
+
+		// Walls
+		const wallMaterial = new THREE.MeshStandardMaterial({
+			color: 0x3a3a5c,
+			roughness: 0.9,
+			metalness: 0.1,
+			side: THREE.DoubleSide,
+		});
+
+		// Back wall
+		const backWall = new THREE.Mesh(new THREE.PlaneGeometry(width, height), wallMaterial);
+		backWall.position.set(0, height / 2, -depth / 2);
+		backWall.receiveShadow = true;
+		this.scene.add(backWall);
+
+		// Front wall
+		const frontWall = new THREE.Mesh(new THREE.PlaneGeometry(width, height), wallMaterial);
+		frontWall.position.set(0, height / 2, depth / 2);
+		frontWall.rotation.y = Math.PI;
+		frontWall.receiveShadow = true;
+		this.scene.add(frontWall);
+
+		// Left wall
+		const leftWall = new THREE.Mesh(new THREE.PlaneGeometry(depth, height), wallMaterial);
+		leftWall.position.set(-width / 2, height / 2, 0);
+		leftWall.rotation.y = Math.PI / 2;
+		leftWall.receiveShadow = true;
+		this.scene.add(leftWall);
+
+		// Right wall
+		const rightWall = new THREE.Mesh(new THREE.PlaneGeometry(depth, height), wallMaterial);
+		rightWall.position.set(width / 2, height / 2, 0);
+		rightWall.rotation.y = -Math.PI / 2;
+		rightWall.receiveShadow = true;
+		this.scene.add(rightWall);
+	}
+
+	/** Start the render loop */
+	start(onFrame?: () => void): void {
+		const animate = (): void => {
+			this.animationId = requestAnimationFrame(animate);
+			onFrame?.();
+			this.renderer.render(this.scene, this.camera);
+		};
+		animate();
+	}
+
+	/** Stop the render loop */
+	stop(): void {
+		if (this.animationId !== null) {
+			cancelAnimationFrame(this.animationId);
+			this.animationId = null;
+		}
+	}
+
+	/** Handle window resize */
+	handleResize(width: number, height: number): void {
+		this.camera.aspect = width / height;
+		this.camera.updateProjectionMatrix();
+		this.renderer.setSize(width, height);
+	}
+
+	/** Get the room dimensions */
+	getDimensions(): Readonly<RoomDimensions> {
+		return { ...this.dimensions };
+	}
+
+	/** Dispose of all Three.js resources */
+	dispose(): void {
+		this.stop();
+		this.scene.traverse((object) => {
+			if (object instanceof THREE.Mesh) {
+				object.geometry.dispose();
+				const material = object.material;
+				if (Array.isArray(material)) {
+					for (const mat of material) {
+						mat.dispose();
+					}
+				} else {
+					material.dispose();
+				}
+			}
+		});
+		this.renderer.dispose();
+	}
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,59 @@
+/**
+ * API response types matching the backend Pydantic schemas.
+ */
+
+export interface Position {
+	x: number;
+	y: number;
+	z: number;
+}
+
+export interface Room {
+	id: string;
+	owner_id: string;
+	name: string;
+	description: string | null;
+	layout_data: Record<string, unknown> | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface RoomCreateRequest {
+	name: string;
+	description?: string | null;
+	layout_data?: Record<string, unknown> | null;
+}
+
+export interface RoomUpdateRequest {
+	name?: string;
+	description?: string | null;
+	layout_data?: Record<string, unknown> | null;
+}
+
+export interface MemoryItem {
+	id: string;
+	room_id: string;
+	content: string;
+	image_url: string | null;
+	position_x: number;
+	position_y: number;
+	position_z: number;
+	ease_factor: number;
+	interval: number;
+	repetitions: number;
+	last_reviewed_at: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface MemoryItemCreateRequest {
+	content: string;
+	image_url?: string | null;
+	position: Position;
+}
+
+export interface MemoryItemUpdateRequest {
+	content?: string;
+	image_url?: string | null;
+	position?: Position;
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -57,3 +57,61 @@ export interface MemoryItemUpdateRequest {
 	image_url?: string | null;
 	position?: Position;
 }
+
+// =============================================================================
+// Review types
+// =============================================================================
+
+export interface ReviewRecordCreate {
+	memory_item_id: string;
+	quality: number;
+	response_time_ms: number;
+}
+
+export interface ReviewRecordResponse {
+	id: string;
+	session_id: string;
+	memory_item_id: string;
+	quality: number;
+	response_time_ms: number;
+	reviewed_at: string;
+}
+
+export interface RoomStatsResponse {
+	total_items: number;
+	reviewed_items: number;
+	mastered_items: number;
+	learning_items: number;
+	new_items: number;
+	average_ease_factor: number | null;
+	total_reviews: number;
+	average_quality: number | null;
+	reviews_today: number;
+}
+
+export interface DailyStatsEntry {
+	date: string;
+	review_count: number;
+	average_quality: number | null;
+	correct_rate: number | null;
+}
+
+export interface DailyStatsResponse {
+	entries: DailyStatsEntry[];
+}
+
+export interface ForgettingCurvePoint {
+	days_since_review: number;
+	retention: number;
+}
+
+export interface ForgettingCurveItem {
+	item_id: string;
+	content: string;
+	stability: number;
+	curve: ForgettingCurvePoint[];
+}
+
+export interface ForgettingCurveResponse {
+	items: ForgettingCurveItem[];
+}


### PR DESCRIPTION
## Summary
- 復習セッションUI: キューからアイテムを順に表示し、quality 0-5 のボタン式自己評価で復習結果を記録
- 統計ダッシュボード: Recharts を使用した日別復習数・正答率の折れ線グラフ、ルーム別記憶定着率の円グラフ、忘却曲線 R(t) = e^(-t/S) の可視化
- バックエンド: 日別統計API (`GET /stats/daily`) と忘却曲線API (`GET /stats/forgetting-curve`) を追加
- 復習アイテムゼロ時の「復習するアイテムがありません」表示、レスポンシブ対応（モバイルでは3Dデスクトップ推奨の警告）

## Changes

### Backend
- `GET /api/rooms/{room_id}/stats/daily?days=30` — 日別の復習数・正答率・平均品質を返す（1-365日範囲フィルタ）
- `GET /api/rooms/{room_id}/stats/forgetting-curve` — 復習済みアイテムの忘却曲線データ（R(t) = e^(-t/S)、最大20件）
- Pydantic schemas: `DailyStatsEntry`, `DailyStatsResponse`, `ForgettingCurvePoint`, `ForgettingCurveItem`, `ForgettingCurveResponse`
- Service layer: `get_daily_stats()`, `get_forgetting_curves()`

### Frontend
- `ReviewSession` component: 復習キュー取得 → 内容非表示 → 「答えを見る」ボタン → quality 0-5 ボタン → 次のアイテム → 完了画面
- `StatsDashboard` component: サマリーカード、日別折れ線グラフ（復習数+正答率）、記憶定着率の円グラフ、忘却曲線プロット
- `reviewApi` client: `getQueue`, `recordReview`, `getStats`, `getDailyStats`, `getForgettingCurve`
- `App.tsx`: 復習・統計ビューへのナビゲーション追加（各ルームに「復習」「統計」ボタン）
- TypeScript types: `ReviewRecordCreate`, `RoomStatsResponse`, `DailyStatsResponse`, `ForgettingCurveResponse` 等

### Tests
- Backend: 17 tests (TestDailyStats: 9, TestForgettingCurve: 8)
- Frontend: 28 tests (ReviewSession: 11, StatsDashboard: 12, reviewApi: 5)
- 全237テスト通過、バックエンドカバレッジ 95%

## Test plan
- [ ] `make check` が全て通過すること（format, lint, typecheck, test, build）
- [ ] 復習キューが空のとき「復習するアイテムがありません」と表示される
- [ ] 復習完了後に統計ダッシュボードに結果が反映される
- [ ] 日別正答率のグラフが日付範囲（7/14/30/90日）で切り替え可能
- [ ] 忘却曲線が復習済みアイテムに対して表示される
- [ ] 存在しない room_id に対して 404 を返す

Closes #11