### PR TITLE
ci: setup-node v6 / setup-python v6 へ更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -52,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip


### PR DESCRIPTION
## 概要
Node.js 20 ランタイムで動作する action を更新する。

- actions/setup-node v4 → v6
- actions/setup-python v5 → v6

## 背景
#35 (Node.js 20 deprecation対応) の残作業。dependabot PR (#86 checkout, #37 fetch-metadata) で一部は更新済みだが、setup-node/setup-python の更新 PR は dependabot が未作成だったため手動対応。

## 検証
- actionlint パス

Refs #35