### PR TITLE
feat(frontend): パスワード強度表示 + Three.js dispose テスト

### DIFF
--- a/frontend/src/components/LoginForm.test.tsx
+++ b/frontend/src/components/LoginForm.test.tsx
@@ -128,4 +128,46 @@ describe("LoginForm", () => {
 
 		expect(mockClearError).toHaveBeenCalled();
 	});
+
+	it("does not show the password strength indicator in login mode", async () => {
+		const user = userEvent.setup();
+		render(<LoginForm />);
+
+		await user.type(screen.getByTestId("auth-password"), "password123");
+
+		expect(screen.queryByTestId("password-strength")).toBeNull();
+	});
+
+	it("does not show the strength indicator in register mode with an empty password", async () => {
+		const user = userEvent.setup();
+		render(<LoginForm />);
+
+		await user.click(screen.getByTestId("auth-toggle"));
+
+		expect(screen.queryByTestId("password-strength")).toBeNull();
+	});
+
+	it("shows a weak strength indicator for a short password in register mode", async () => {
+		const user = userEvent.setup();
+		render(<LoginForm />);
+
+		await user.click(screen.getByTestId("auth-toggle"));
+		await user.type(screen.getByTestId("auth-password"), "abc");
+
+		const indicator = screen.getByTestId("password-strength");
+		expect(indicator).toHaveAttribute("data-strength", "weak");
+		expect(screen.getByTestId("password-strength-label")).toHaveTextContent("弱い");
+	});
+
+	it("shows a strong strength indicator for a complex password in register mode", async () => {
+		const user = userEvent.setup();
+		render(<LoginForm />);
+
+		await user.click(screen.getByTestId("auth-toggle"));
+		await user.type(screen.getByTestId("auth-password"), "Str0ng!Pass");
+
+		const indicator = screen.getByTestId("password-strength");
+		expect(indicator).toHaveAttribute("data-strength", "strong");
+		expect(screen.getByTestId("password-strength-label")).toHaveTextContent("強い");
+	});
 });

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -5,8 +5,21 @@
 
 import { useCallback, useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
+import { getPasswordStrength, type PasswordStrength, passwordStrengthPercent } from "@/lib/passwordStrength";
 
 type Mode = "login" | "register";
+
+const STRENGTH_COLORS: Record<PasswordStrength, string> = {
+	weak: "#ff4444",
+	medium: "#ffaa00",
+	strong: "#00cc66",
+};
+
+const STRENGTH_LABELS: Record<PasswordStrength, string> = {
+	weak: "弱い",
+	medium: "普通",
+	strong: "強い",
+};
 
 function isFormValid(mode: Mode, username: string, email: string, password: string): boolean {
 	if (mode === "login") {
@@ -48,6 +61,7 @@ export function LoginForm(): React.JSX.Element {
 	);
 
 	const canSubmit = isFormValid(mode, username, email, password) && !submitting;
+	const passwordStrength = getPasswordStrength(password);
 
 	return (
 		<div style={styles.wrapper}>
@@ -114,6 +128,29 @@ export function LoginForm(): React.JSX.Element {
 							style={styles.input}
 							data-testid="auth-password"
 						/>
+						{mode === "register" && password.length > 0 && (
+							<div
+								style={styles.strengthWrapper}
+								data-testid="password-strength"
+								data-strength={passwordStrength.label}
+							>
+								<div style={styles.strengthTrack}>
+									<div
+										style={{
+											...styles.strengthFill,
+											width: `${passwordStrengthPercent(passwordStrength)}%`,
+											backgroundColor: STRENGTH_COLORS[passwordStrength.label],
+										}}
+									/>
+								</div>
+								<span
+									style={{ ...styles.strengthLabel, color: STRENGTH_COLORS[passwordStrength.label] }}
+									data-testid="password-strength-label"
+								>
+									{STRENGTH_LABELS[passwordStrength.label]}
+								</span>
+							</div>
+						)}
 					</div>
 
 					<button
@@ -205,6 +242,29 @@ const styles = {
 		fontSize: "0.95rem",
 		outline: "none",
 		boxSizing: "border-box" as const,
+	},
+	strengthWrapper: {
+		display: "flex",
+		alignItems: "center",
+		gap: "8px",
+		marginTop: "8px",
+	},
+	strengthTrack: {
+		flex: 1,
+		height: "6px",
+		backgroundColor: "#2a2a4a",
+		borderRadius: "3px",
+		overflow: "hidden",
+	},
+	strengthFill: {
+		height: "100%",
+		borderRadius: "3px",
+		transition: "width 0.2s ease, background-color 0.2s ease",
+	},
+	strengthLabel: {
+		fontSize: "0.8rem",
+		minWidth: "2.5em",
+		textAlign: "right" as const,
 	},
 	submitButton: {
 		width: "100%",

--- a/frontend/src/lib/passwordStrength.test.ts
+++ b/frontend/src/lib/passwordStrength.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { getPasswordStrength, passwordStrengthPercent } from "./passwordStrength";
+
+describe("getPasswordStrength", () => {
+	it("returns weak with score 0 for an empty password", () => {
+		const result = getPasswordStrength("");
+		expect(result.score).toBe(0);
+		expect(result.label).toBe("weak");
+	});
+
+	it("rates a short simple password as weak", () => {
+		// Only the lower/upper criterion is met (length < 8, no digit/symbol).
+		const result = getPasswordStrength("Abc");
+		expect(result.score).toBe(1);
+		expect(result.label).toBe("weak");
+	});
+
+	it("rates a medium password", () => {
+		// length >= 8 + digit = score 2.
+		const result = getPasswordStrength("password1");
+		expect(result.score).toBe(2);
+		expect(result.label).toBe("medium");
+	});
+
+	it("rates a strong password meeting all criteria", () => {
+		// length >= 8 + mixed case + digit + symbol = score 4.
+		const result = getPasswordStrength("Str0ng!Pass");
+		expect(result.score).toBe(4);
+		expect(result.label).toBe("strong");
+	});
+
+	it("does not exceed a score of 4", () => {
+		const result = getPasswordStrength("A_very-Str0ng!Password#2026");
+		expect(result.score).toBe(4);
+		expect(result.label).toBe("strong");
+	});
+});
+
+describe("passwordStrengthPercent", () => {
+	it("maps score to a 0-100 percentage", () => {
+		expect(passwordStrengthPercent({ score: 0, label: "weak" })).toBe(0);
+		expect(passwordStrengthPercent({ score: 2, label: "medium" })).toBe(50);
+		expect(passwordStrengthPercent({ score: 4, label: "strong" })).toBe(100);
+	});
+});

--- a/frontend/src/lib/passwordStrength.ts
+++ b/frontend/src/lib/passwordStrength.ts
@@ -1,0 +1,59 @@
+/**
+ * Password strength estimation.
+ *
+ * A deliberately simple length + character-variety heuristic (no external
+ * dependency). One point is awarded for each satisfied criterion:
+ *   - length >= 8
+ *   - contains both lower and upper case letters
+ *   - contains a digit
+ *   - contains a symbol (non-alphanumeric)
+ * The resulting 0-4 score maps to a weak / medium / strong label.
+ */
+
+export type PasswordStrength = "weak" | "medium" | "strong";
+
+export interface PasswordStrengthResult {
+	/** Number of satisfied criteria, 0-4. */
+	score: number;
+	/** Human-facing strength bucket. */
+	label: PasswordStrength;
+}
+
+const MAX_SCORE = 4;
+
+/** Estimate the strength of a password. */
+export function getPasswordStrength(password: string): PasswordStrengthResult {
+	if (password.length === 0) {
+		return { score: 0, label: "weak" };
+	}
+
+	let score = 0;
+	if (password.length >= 8) {
+		score += 1;
+	}
+	if (/[a-z]/.test(password) && /[A-Z]/.test(password)) {
+		score += 1;
+	}
+	if (/\d/.test(password)) {
+		score += 1;
+	}
+	if (/[^A-Za-z0-9]/.test(password)) {
+		score += 1;
+	}
+
+	let label: PasswordStrength;
+	if (score <= 1) {
+		label = "weak";
+	} else if (score <= 3) {
+		label = "medium";
+	} else {
+		label = "strong";
+	}
+
+	return { score, label };
+}
+
+/** Score expressed as a 0-100 percentage, useful for a progress bar width. */
+export function passwordStrengthPercent(result: PasswordStrengthResult): number {
+	return Math.round((result.score / MAX_SCORE) * 100);
+}

--- a/frontend/src/lib/three/FirstPersonControls.test.ts
+++ b/frontend/src/lib/three/FirstPersonControls.test.ts
@@ -1,0 +1,60 @@
+import * as THREE from "three";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { FirstPersonControls } from "./FirstPersonControls";
+import type { RoomDimensions } from "./RoomScene";
+
+const DIMENSIONS: RoomDimensions = { width: 20, height: 4, depth: 20 };
+
+function makeControls() {
+	const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+	const domElement = document.createElement("div");
+	const controls = new FirstPersonControls(camera, domElement, DIMENSIONS);
+	return { controls, camera, domElement };
+}
+
+describe("FirstPersonControls", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("starts unlocked", () => {
+		const { controls } = makeControls();
+		expect(controls.getIsLocked()).toBe(false);
+		controls.disconnect();
+	});
+
+	it("removes every event listener on disconnect", () => {
+		const documentRemove = vi.spyOn(document, "removeEventListener");
+		const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+		const domElement = document.createElement("div");
+		const domRemove = vi.spyOn(domElement, "removeEventListener");
+
+		const controls = new FirstPersonControls(camera, domElement, DIMENSIONS);
+		controls.disconnect();
+
+		expect(documentRemove).toHaveBeenCalledWith("mousemove", expect.any(Function));
+		expect(documentRemove).toHaveBeenCalledWith("keydown", expect.any(Function));
+		expect(documentRemove).toHaveBeenCalledWith("keyup", expect.any(Function));
+		expect(documentRemove).toHaveBeenCalledWith("pointerlockchange", expect.any(Function));
+		expect(domRemove).toHaveBeenCalledWith("click", expect.any(Function));
+	});
+
+	it("removes the same handler references it added", () => {
+		const added: Record<string, EventListenerOrEventListenerObject> = {};
+		const removed: Record<string, EventListenerOrEventListenerObject> = {};
+		vi.spyOn(document, "addEventListener").mockImplementation((type, handler) => {
+			added[type] = handler as EventListenerOrEventListenerObject;
+		});
+		vi.spyOn(document, "removeEventListener").mockImplementation((type, handler) => {
+			removed[type] = handler as EventListenerOrEventListenerObject;
+		});
+
+		const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+		const controls = new FirstPersonControls(camera, document.createElement("div"), DIMENSIONS);
+		controls.disconnect();
+
+		for (const type of ["mousemove", "keydown", "keyup", "pointerlockchange"]) {
+			expect(removed[type]).toBe(added[type]);
+		}
+	});
+});

--- a/frontend/src/lib/three/ItemManager.test.ts
+++ b/frontend/src/lib/three/ItemManager.test.ts
@@ -1,0 +1,77 @@
+import * as THREE from "three";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ItemManager } from "./ItemManager";
+import type { RoomDimensions } from "./RoomScene";
+
+const DIMENSIONS: RoomDimensions = { width: 20, height: 4, depth: 20 };
+
+/** A minimal 2D context stub — jsdom does not implement canvas 2D. */
+function fakeContext(): CanvasRenderingContext2D {
+	return {
+		fillStyle: "",
+		font: "",
+		textAlign: "",
+		textBaseline: "",
+		fillRect: vi.fn(),
+		roundRect: vi.fn(),
+		fill: vi.fn(),
+		fillText: vi.fn(),
+	} as unknown as CanvasRenderingContext2D;
+}
+
+function makeManager() {
+	const scene = new THREE.Scene();
+	const camera = new THREE.PerspectiveCamera(70, 1, 0.1, 100);
+	const manager = new ItemManager(scene, camera, DIMENSIONS);
+	return { manager, scene, camera };
+}
+
+describe("ItemManager", () => {
+	beforeEach(() => {
+		vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(fakeContext());
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("removeItem returns false for an unknown id", () => {
+		const { manager } = makeManager();
+		expect(manager.removeItem("missing")).toBe(false);
+	});
+
+	it("removeItem disposes the item's geometries and materials", () => {
+		const geometryDispose = vi.spyOn(THREE.BufferGeometry.prototype, "dispose");
+		const materialDispose = vi.spyOn(THREE.Material.prototype, "dispose");
+
+		const { manager, scene } = makeManager();
+		manager.addItem("item-1", "Capital of France", new THREE.Vector3(1, 0, 1));
+		// Placement indicator + item group.
+		expect(scene.children).toHaveLength(2);
+
+		const removed = manager.removeItem("item-1");
+
+		expect(removed).toBe(true);
+		expect(manager.getAllItems().size).toBe(0);
+		expect(scene.children).toHaveLength(1); // only the placement indicator remains
+		expect(geometryDispose).toHaveBeenCalled();
+		expect(materialDispose).toHaveBeenCalled();
+	});
+
+	it("dispose releases all items and the placement indicator", () => {
+		const geometryDispose = vi.spyOn(THREE.BufferGeometry.prototype, "dispose");
+		const materialDispose = vi.spyOn(THREE.Material.prototype, "dispose");
+
+		const { manager } = makeManager();
+		manager.addItem("item-1", "One", new THREE.Vector3(1, 0, 1));
+		manager.addItem("item-2", "Two", new THREE.Vector3(-1, 0, -1));
+		expect(manager.getAllItems().size).toBe(2);
+
+		manager.dispose();
+
+		expect(manager.getAllItems().size).toBe(0);
+		// Geometry disposed for both item markers and the placement indicator.
+		expect(geometryDispose.mock.calls.length).toBeGreaterThanOrEqual(3);
+		expect(materialDispose).toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/three/RoomScene.test.ts
+++ b/frontend/src/lib/three/RoomScene.test.ts
@@ -1,0 +1,66 @@
+import * as THREE from "three";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// jsdom has no WebGL context, so replace only WebGLRenderer with a lightweight
+// stub and keep the rest of three real (geometries, materials, scene graph).
+vi.mock("three", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("three")>();
+	class FakeWebGLRenderer {
+		domElement: HTMLCanvasElement;
+		shadowMap = { enabled: false, type: 0 };
+		constructor(params?: { canvas?: HTMLCanvasElement }) {
+			this.domElement = params?.canvas ?? document.createElement("canvas");
+		}
+		setSize = vi.fn();
+		setPixelRatio = vi.fn();
+		render = vi.fn();
+		dispose = vi.fn();
+	}
+	return { ...actual, WebGLRenderer: FakeWebGLRenderer };
+});
+
+// Imported after the mock is registered (vi.mock is hoisted by Vitest).
+const { RoomScene } = await import("./RoomScene");
+
+function makeCanvas(): HTMLCanvasElement {
+	const canvas = document.createElement("canvas");
+	Object.defineProperty(canvas, "clientWidth", { value: 800, configurable: true });
+	Object.defineProperty(canvas, "clientHeight", { value: 600, configurable: true });
+	return canvas;
+}
+
+describe("RoomScene", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("builds a scene populated with room geometry", () => {
+		const room = new RoomScene(makeCanvas());
+		expect(room.scene.children.length).toBeGreaterThan(0);
+	});
+
+	it("disposes geometries, materials and the renderer", () => {
+		const geometryDispose = vi.spyOn(THREE.BufferGeometry.prototype, "dispose");
+		const materialDispose = vi.spyOn(THREE.Material.prototype, "dispose");
+
+		const room = new RoomScene(makeCanvas());
+		const rendererDispose = room.renderer.dispose as ReturnType<typeof vi.fn>;
+
+		room.dispose();
+
+		expect(geometryDispose).toHaveBeenCalled();
+		expect(materialDispose).toHaveBeenCalled();
+		expect(rendererDispose).toHaveBeenCalled();
+	});
+
+	it("stops the render loop on dispose", () => {
+		const cancelSpy = vi.spyOn(globalThis, "cancelAnimationFrame");
+		vi.spyOn(globalThis, "requestAnimationFrame").mockReturnValue(42);
+
+		const room = new RoomScene(makeCanvas());
+		room.start();
+		room.dispose();
+
+		expect(cancelSpy).toHaveBeenCalledWith(42);
+	});
+});


### PR DESCRIPTION
## 概要
フロントエンド品質系の Issue 2件をまとめて対応。

## 変更内容
- **#32** LoginForm（登録モード）にパスワード強度インジケータを追加。外部ライブラリ非依存の「長さ + 文字種」ヒューリスティック（`lib/passwordStrength.ts`）で weak/medium/strong を判定し、バーとラベル（弱い/普通/強い）で表示。ログインモードやパスワード未入力時は非表示。
- **#33** Three.js レイヤのリソース解放テストを追加。
  - `FirstPersonControls`: `disconnect()` が全イベントリスナー（document の mousemove/keydown/keyup/pointerlockchange + domElement の click）を、登録時と同じ関数参照で解放することを検証。
  - `RoomScene`: `dispose()` がジオメトリ・マテリアル・レンダラーを解放し、レンダーループを停止することを検証（jsdom に WebGL がないため `WebGLRenderer` のみスタブ）。
  - `ItemManager`: `removeItem`/`dispose()` がアイテムと配置インジケータのジオメトリ・マテリアルを解放することを検証（canvas 2D をスタブ）。

## テスト
- `lib/passwordStrength.test.ts`（新規）+ `LoginForm.test.tsx`（追加）+ three 3ファイルの新規テスト。
- frontend 91 passed（+19）。tsc / oxlint / biome クリーン、`vite build` 成功。backend も 215 passed（pre-commit で確認）。

Fixes #33
Fixes #32